### PR TITLE
Remove numpy backend

### DIFF
--- a/benchmarks/solvers/bench_cycle_reduction.py
+++ b/benchmarks/solvers/bench_cycle_reduction.py
@@ -17,7 +17,7 @@ class CycleReduction:
         self.nb_cycle_reduction = nb_cycle_reduction
 
         # Build model and extract linearization matrices
-        m = model_from_gcn(get_example_gcn(model), verbose=False, backend="numpy")
+        m = model_from_gcn(get_example_gcn(model), verbose=False)
         m.steady_state(verbose=False)
         A, B, C, _D = m.linearize_model(verbose=False)
 

--- a/benchmarks/solvers/bench_gensys.py
+++ b/benchmarks/solvers/bench_gensys.py
@@ -15,7 +15,7 @@ class Gensys:
         self.solve_gensys = solve_policy_function_with_gensys
 
         # Build model and extract linearization matrices
-        m = model_from_gcn(get_example_gcn(model), verbose=False, backend="numpy")
+        m = model_from_gcn(get_example_gcn(model), verbose=False)
         m.steady_state(verbose=False)
         A, B, C, D = m.linearize_model(verbose=False)
 

--- a/conda_envs/environment.yml
+++ b/conda_envs/environment.yml
@@ -23,7 +23,7 @@ dependencies:
   - ipython
   - nutpie
   - networkx
-  - sympytensor>=1.4.0
+  - sympytensor>=1.4.1
   - pymc-extras
 
   - pip:

--- a/conda_envs/environment_dev.yml
+++ b/conda_envs/environment_dev.yml
@@ -24,7 +24,7 @@ dependencies:
   - notebook<7
   - nutpie
   - networkx
-  - sympytensor>=1.4.0
+  - sympytensor>=1.4.1
   - pymc-extras>=0.8.0
 
   # For building docs

--- a/conda_envs/environment_docs.yml
+++ b/conda_envs/environment_docs.yml
@@ -20,7 +20,7 @@ dependencies:
   - sympy>=1.14.0
   - pymc-extras>=0.8.0
   - better-optimize
-  - sympytensor>=1.4.0
+  - sympytensor>=1.4.1
   - jax
   - nutpie
   - networkx

--- a/conda_envs/geconpy_test.yml
+++ b/conda_envs/geconpy_test.yml
@@ -18,7 +18,7 @@ dependencies:
   - pytensor>=2.37.0
   - preliz>=0.23.0
   - ipython
-  - sympytensor>=1.4.0
+  - sympytensor>=1.4.1
   - pymc-extras>=0.8.0
   - better-optimize
   - nutpie

--- a/gEconpy/model/parameters.py
+++ b/gEconpy/model/parameters.py
@@ -2,7 +2,6 @@ from collections.abc import Callable
 
 from gEconpy.classes.containers import SymbolDictionary
 from gEconpy.model.compile import (
-    BACKENDS,
     compile_function,
     dictionary_return_wrapper,
     make_return_dict_and_update_cache,
@@ -12,7 +11,6 @@ from gEconpy.model.compile import (
 def compile_param_dict_func(
     param_dict: SymbolDictionary,
     deterministic_dict: SymbolDictionary,
-    backend: BACKENDS = "numpy",
     cache: dict | None = None,
     return_symbolic: bool = False,
 ) -> tuple[Callable, dict]:
@@ -29,15 +27,13 @@ def compile_param_dict_func(
     deterministic_dict: SymbolDictionary
         A dictionary of deterministic parameters, with the keys being the parameters and the values being the
         expressions to compute them.
-    backend: str, one of "numpy", "pytensor"
-        The backend to use for the compiled function.
     cache: dict, optional
         A dictionary mapping from pytensor symbols to sympy expressions. Used to prevent duplicate mappings from
         sympy symbol to pytensor symbol from being created. Default is a empty dictionary, implying no other functions
         have been compiled yet.
     return_symbolic: bool, default False
-        When true, if backend is "pytensor", return a symbolic graph representing the computation of parameter values
-        rather than a compiled pytensor function. Ignored if backend is not "pytensor"
+        When true, return a symbolic graph representing the computation of parameter values
+        rather than a compiled pytensor function.
 
     Returns
     -------
@@ -56,14 +52,13 @@ def compile_param_dict_func(
     f, cache = compile_function(
         inputs,
         output_exprs,
-        backend=backend,
         cache=cache,
         return_symbolic=return_symbolic,
         pop_return=False,
         stack_return=not return_symbolic,
     )
 
-    if return_symbolic and backend == "pytensor":
+    if return_symbolic:
         return make_return_dict_and_update_cache(output_params, f, cache)
 
     return dictionary_return_wrapper(f, output_params), cache

--- a/gEconpy/model/perturbation.py
+++ b/gEconpy/model/perturbation.py
@@ -16,7 +16,7 @@ from scipy import linalg
 
 from gEconpy.classes.containers import SymbolDictionary
 from gEconpy.classes.time_aware_symbol import TimeAwareSymbol
-from gEconpy.model.compile import BACKENDS, compile_function
+from gEconpy.model.compile import compile_function
 from gEconpy.solvers.gensys import _gensys_setup
 from gEconpy.utilities import eq_to_ss, get_name, simplify_matrix
 
@@ -266,7 +266,6 @@ def compile_linearized_system(
     deterministic_dict: SymbolDictionary[sp.Symbol, sp.Expr],
     calib_dict: SymbolDictionary[sp.Symbol, float | sp.Expr],
     shocks: list[TimeAwareSymbol],
-    backend: BACKENDS = "numpy",
     return_symbolic: bool = False,
     cache: dict | None = None,
     **kwargs,
@@ -282,7 +281,6 @@ def compile_linearized_system(
     deterministic_dict
     calib_dict
     shocks
-    backend
     return_symbolic
     cache
     kwargs
@@ -292,7 +290,7 @@ def compile_linearized_system(
     f_linearze: Callable
         Function that evaluates the linearized system of equations.
     cache: dict
-        Dictionary mapping sympy symbols to pytensor tensors. Empty if backend is not pytensor
+        Dictionary mapping sympy symbols to pytensor tensors.
     """
     cache = {} if cache is None else cache
 
@@ -308,7 +306,6 @@ def compile_linearized_system(
     f_linearize, cache = compile_function(
         inputs,
         outputs,
-        backend=backend,
         cache=cache,
         return_symbolic=return_symbolic,
         **kwargs,

--- a/gEconpy/pytensorf/compile.py
+++ b/gEconpy/pytensorf/compile.py
@@ -1,0 +1,144 @@
+from functools import lru_cache
+
+import pytensor
+
+from pymc.pytensorf import rewrite_pregrad
+from pytensor.compile.function.types import Function
+from pytensor.compile.mode import Mode
+from pytensor.compile.profiling import ProfileStats
+from pytensor.tensor.variable import TensorVariable
+
+
+@lru_cache(maxsize=128)
+def _compile_cached(
+    inputs: tuple[TensorVariable, ...],
+    outputs: TensorVariable | tuple[TensorVariable, ...],
+    mode: str | Mode | None = None,
+    updates: tuple[tuple[TensorVariable, TensorVariable], ...] | None = None,
+    givens: tuple[tuple[TensorVariable, TensorVariable], ...] | None = None,
+    no_default_updates: bool = False,
+    accept_inplace: bool = False,
+    name: str | None = None,
+    rebuild_strict: bool = True,
+    allow_input_downcast: bool | None = None,
+    profile: bool | ProfileStats | None = None,
+    on_unused_input: str | None = "ignore",
+    trust_input: bool = False,
+) -> Function:
+    """Compile pytensor function with caching."""
+    if isinstance(outputs, tuple):
+        outputs = list(outputs)
+
+    outputs = rewrite_pregrad(outputs)
+
+    return pytensor.function(
+        list(inputs),
+        outputs,
+        mode=mode,
+        updates=dict(updates) if updates is not None else None,
+        givens=dict(givens) if givens is not None else None,
+        no_default_updates=no_default_updates,
+        accept_inplace=accept_inplace,
+        name=name,
+        rebuild_strict=rebuild_strict,
+        allow_input_downcast=allow_input_downcast,
+        profile=profile,
+        on_unused_input=on_unused_input,
+        trust_input=trust_input,
+    )
+
+
+def compile_pytensor_function(
+    inputs: list[TensorVariable],
+    outputs: TensorVariable | list[TensorVariable],
+    mode: str | Mode | None = None,
+    updates: dict[TensorVariable, TensorVariable] | list[tuple[TensorVariable, TensorVariable]] | None = None,
+    givens: dict[TensorVariable, TensorVariable] | list[tuple[TensorVariable, TensorVariable]] | None = None,
+    no_default_updates: bool = False,
+    accept_inplace: bool = False,
+    name: str | None = None,
+    rebuild_strict: bool = True,
+    allow_input_downcast: bool | None = None,
+    profile: bool | ProfileStats | None = None,
+    on_unused_input: str | None = "ignore",
+    trust_input: bool = False,
+) -> Function:
+    """Compile a pytensor graph to a callable function.
+
+    Wraps ``pytensor.function`` with:
+
+    - Pre-grad rewrites (canonicalize + stabilize) via ``rewrite_pregrad``
+    - Function caching via ``functools.cache`` (identity-based on graph nodes)
+    - ``on_unused_input="ignore"`` by default
+
+    All parameters mirror ``pytensor.function`` except for the changed defaults
+    noted above.
+
+    Parameters
+    ----------
+    inputs : list of TensorVariable
+        Input nodes for the compiled function.
+    outputs : TensorVariable or list of TensorVariable
+        Output nodes for the compiled function.
+    mode : str or Mode, optional
+        Pytensor compilation mode. Common values: ``"FAST_COMPILE"``
+        (Python, no C), ``"FAST_RUN"`` (C compilation), ``"JAX"``
+        (JAX backend). Default is ``None`` (pytensor's default).
+    updates : dict or list of tuples, optional
+        Expressions for shared variable updates.
+    givens : dict or list of tuples, optional
+        Substitutions to apply before compiling.
+    no_default_updates : bool
+        If True, do not perform default updates on shared variables.
+    accept_inplace : bool
+        If True, accept graph with in-place operations.
+    name : str, optional
+        Name for the compiled function (for debugging).
+    rebuild_strict : bool
+        If True, require inputs to match graph exactly.
+    allow_input_downcast : bool, optional
+        If True, allow numeric inputs to be silently downcast.
+    profile : bool or ProfileStats, optional
+        If True, enable profiling.
+    on_unused_input : str, optional
+        What to do if an input is unused. Default is ``"ignore"``.
+    trust_input : bool
+        If True, skip input validation at call time. Default is ``False``.
+
+    Returns
+    -------
+    f : pytensor.function
+        Compiled callable.
+    """
+    if isinstance(outputs, list):
+        outputs = tuple(outputs)
+
+    # Convert mutable containers to hashable tuples for caching
+    frozen_updates = tuple(updates.items() if isinstance(updates, dict) else updates) if updates is not None else None
+    frozen_givens = tuple(givens.items() if isinstance(givens, dict) else givens) if givens is not None else None
+
+    return _compile_cached(
+        tuple(inputs),
+        outputs,
+        mode=mode,
+        updates=frozen_updates,
+        givens=frozen_givens,
+        no_default_updates=no_default_updates,
+        accept_inplace=accept_inplace,
+        name=name,
+        rebuild_strict=rebuild_strict,
+        allow_input_downcast=allow_input_downcast,
+        profile=profile,
+        on_unused_input=on_unused_input,
+        trust_input=trust_input,
+    )
+
+
+def clear_compile_cache() -> None:
+    """Release all cached compiled functions."""
+    _compile_cached.cache_clear()
+
+
+def compile_cache_info():
+    """Return cache statistics (hits, misses, maxsize, currsize)."""
+    return _compile_cached.cache_info()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     "scipy",
     "setuptools",
     "sympy>=1.14.0",
-    "sympytensor>=1.4.0",
+    "sympytensor>=1.4.1",
     "ipython",
     "xarray",
     "networkx"

--- a/tests/_resources/cache_compiled_models.py
+++ b/tests/_resources/cache_compiled_models.py
@@ -5,19 +5,10 @@ from gEconpy import model_from_gcn, statespace_from_gcn
 
 
 @cache
-def load_and_cache_model(gcn_file, backend, use_jax=False, infer_steady_state=True):
-    compile_kwargs = {}
-    if backend == "pytensor" and use_jax:
-        compile_kwargs["mode"] = "JAX"
-
+def load_and_cache_model(gcn_file, infer_steady_state=True):
+    mode = "FAST_RUN"
     gcn_path = Path("tests") / "_resources" / "test_gcns" / gcn_file
-    return model_from_gcn(
-        gcn_path,
-        verbose=False,
-        backend=backend,
-        infer_steady_state=infer_steady_state,
-        **compile_kwargs,
-    )
+    return model_from_gcn(gcn_path, verbose=False, infer_steady_state=infer_steady_state, mode=mode)
 
 
 @cache

--- a/tests/model/perfect_foresight/test_compile.py
+++ b/tests/model/perfect_foresight/test_compile.py
@@ -6,7 +6,7 @@ from tests._resources.cache_compiled_models import load_and_cache_model
 
 @pytest.fixture
 def rbc_model():
-    return load_and_cache_model("one_block_1.gcn", backend="numpy")
+    return load_and_cache_model("one_block_1.gcn")
 
 
 class TestCompile:

--- a/tests/model/perfect_foresight/test_solve.py
+++ b/tests/model/perfect_foresight/test_solve.py
@@ -10,17 +10,17 @@ from tests._resources.cache_compiled_models import load_and_cache_model
 
 @pytest.fixture
 def rbc_model():
-    return load_and_cache_model("one_block_1.gcn", backend="numpy")
+    return load_and_cache_model("one_block_1.gcn")
 
 
 @pytest.fixture
 def backward_var_model():
-    return load_and_cache_model("backward_var.gcn", backend="numpy")
+    return load_and_cache_model("backward_var.gcn")
 
 
 @pytest.fixture
 def forward_model():
-    return load_and_cache_model("3_eq_linear_nk.gcn", backend="numpy")
+    return load_and_cache_model("3_eq_linear_nk.gcn")
 
 
 class TestSolve:

--- a/tests/model/test_compile.py
+++ b/tests/model/test_compile.py
@@ -1,5 +1,3 @@
-from typing import Literal
-
 import numpy as np
 import pytensor.tensor as pt
 import pytest
@@ -7,13 +5,10 @@ import sympy as sp
 
 from gEconpy.classes.containers import SymbolDictionary
 from gEconpy.model.compile import (
-    BACKENDS,
-    array_return_wrapper,
     compile_function,
     dictionary_return_wrapper,
     make_return_dict_and_update_cache,
-    pop_return_wrapper,
-    stack_return_wrapper,
+    sympy_to_pytensor,
 )
 
 
@@ -32,132 +27,100 @@ def test_dictionary_return_wrapper():
     assert result["b"] == 2.0
 
 
-@pytest.mark.parametrize("backend", ["numpy", "pytensor"])
-def test_scalar_function(backend: Literal["numpy", "pytensor"]):
+def test_scalar_function():
     x = sp.symbols("x")
     f = x**2
-    f_func, _ = compile_function([x], f, backend=backend, mode="FAST_COMPILE", pop_return=backend == "pytensor")
-    assert f_func(x=2) == 4
+    f_func, _ = compile_function([x], f, mode="FAST_COMPILE", pop_return=True)
+    result = f_func(x=np.float64(2))
+    np.testing.assert_allclose(result, 4.0)
 
 
-@pytest.mark.parametrize("backend", ["numpy", "pytensor"])
 @pytest.mark.parametrize("stack_return", [True, False])
-def test_multiple_outputs(backend: Literal["numpy", "pytensor"], stack_return: bool):
-    x, y, z = sp.symbols("x y z ")
+def test_multiple_outputs(stack_return: bool):
+    x, y, z = sp.symbols("x y z")
     x2 = x**2
     y2 = y**2
     z2 = z**2
     f_func, _ = compile_function(
         [x, y, z],
         [x2, y2, z2],
-        backend=backend,
         stack_return=stack_return,
         mode="FAST_COMPILE",
     )
-    res = f_func(x=2, y=3, z=4)
-    assert isinstance(res, np.ndarray) if stack_return else isinstance(res, list | tuple)
-    assert res.shape == (3,) if stack_return else len(res) == 3
-    np.testing.assert_allclose(res if stack_return else np.stack(res), np.array([4.0, 9.0, 16.0]))
+    res = f_func(x=np.float64(2), y=np.float64(3), z=np.float64(4))
+    if stack_return:
+        assert isinstance(res, np.ndarray)
+        assert res.shape == (3,)
+        np.testing.assert_allclose(res, np.array([4.0, 9.0, 16.0]))
+    else:
+        assert isinstance(res, list)
+        assert len(res) == 3
+        np.testing.assert_allclose(np.stack(res), np.array([4.0, 9.0, 16.0]))
 
 
-@pytest.mark.parametrize("backend", ["numpy", "pytensor"])
-def test_matrix_function(backend: Literal["numpy", "pytensor"]):
+def test_matrix_function():
     x, y, z = sp.symbols("x y z")
     f = sp.Matrix([x, y, z]).reshape(1, 3)
 
     f_func, _ = compile_function(
         [x, y, z],
         f,
-        backend=backend,
         mode="FAST_COMPILE",
-        pop_return=backend == "pytensor",
+        pop_return=True,
     )
-    res = f_func(x=2, y=3, z=4)
+    res = f_func(x=np.float64(2), y=np.float64(3), z=np.float64(4))
 
     assert isinstance(res, np.ndarray)
     assert res.shape == (1, 3)
     np.testing.assert_allclose(res, np.array([[2.0, 3.0, 4.0]]))
 
 
-@pytest.mark.parametrize("backend", ["numpy", "pytensor"])
-def test_compile_gradient(backend: BACKENDS):
+def test_compile_gradient():
     x, y, z = sp.symbols("x y z")
     f = x**2 + y**2 + z**2
     grad = sp.Matrix([f.diff(x), f.diff(y), f.diff(z)]).reshape(3, 1)
     grad_func, _ = compile_function(
         [x, y, z],
         grad,
-        backend=backend,
         mode="FAST_COMPILE",
-        pop_return=backend == "pytensor",
+        pop_return=True,
     )
-    res = grad_func(x=2.0, y=3.0, z=4.0)
+    res = grad_func(x=np.float64(2.0), y=np.float64(3.0), z=np.float64(4.0))
     np.testing.assert_allclose(res, np.array([4.0, 6.0, 8.0])[:, None])
 
     hess = grad.jacobian([x, y, z])
     hess_func, _ = compile_function(
         [x, y, z],
         hess,
-        backend=backend,
         mode="FAST_COMPILE",
-        pop_return=backend == "pytensor",
+        pop_return=True,
     )
-    res = hess_func(x=2.0, y=3.0, z=4.0)
+    res = hess_func(x=np.float64(2.0), y=np.float64(3.0), z=np.float64(4.0))
     np.testing.assert_allclose(res, np.eye(3) * 2.0)
 
 
-def test_compile_function_invalid_backend():
+def test_sympy_to_pytensor():
+    x, y = sp.symbols("x y")
+    z_expr = x**2 + y
+
+    input_nodes, output_nodes, cache = sympy_to_pytensor([x, y], [z_expr])
+
+    assert len(input_nodes) == 2
+    assert len(output_nodes) == 1
+    assert all(hasattr(n, "type") for n in input_nodes)
+    assert all(hasattr(n, "type") for n in output_nodes)
+    assert len(cache) > 0
+
+
+def test_sympy_to_pytensor_shared_cache():
     x = sp.symbols("x")
-    with pytest.raises(NotImplementedError):
-        compile_function([x], x**2, backend="invalid_backend")
+    cache = {}
 
+    _, _, cache = sympy_to_pytensor([x], [x**2], cache)
+    _, out2, cache = sympy_to_pytensor([x], [x**3], cache)
 
-def test_stack_return_wrapper_list():
-    def f(x):
-        return [x, x + 1, x + 2]
-
-    wrapped = stack_return_wrapper(f)
-    res = wrapped(1)
-    assert isinstance(res, np.ndarray)
-    np.testing.assert_array_equal(res, np.array([1, 2, 3]))
-
-
-def test_stack_return_wrapper_scalar():
-    def f(x):
-        return x + 5
-
-    wrapped = stack_return_wrapper(f)
-    res = wrapped(2)
-    assert isinstance(res, np.ndarray)
-    np.testing.assert_array_equal(res, np.array([7]))
-
-
-def test_pop_return_wrapper_scalar():
-    def f(x):
-        return [x + 10]
-
-    wrapped = pop_return_wrapper(f)
-    res = wrapped(3)
-    assert res == 13
-
-
-def test_pop_return_wrapper_array():
-    def f(x):
-        return [x, x + 1]
-
-    wrapped = pop_return_wrapper(f)
-    res = wrapped(4)
-    assert res == 4
-
-
-def test_array_return_wrapper():
-    def f(x):
-        return [x, x + 1]
-
-    wrapped = array_return_wrapper(f)
-    res = wrapped(5)
-    assert isinstance(res, np.ndarray)
-    np.testing.assert_array_equal(res, np.array([5, 6]))
+    # Second call should reuse the same input node from cache
+    assert len(out2) == 1
 
 
 def test_make_return_dict_and_update_cache():

--- a/tests/model/test_parameters.py
+++ b/tests/model/test_parameters.py
@@ -33,11 +33,10 @@ def complex_param_system():
     return param_dict, deterministic_dict
 
 
-@pytest.mark.parametrize("backend", ["numpy", "pytensor"])
-def test_compile_param_dict_basic(simple_param_system, backend):
+def test_compile_param_dict_basic(simple_param_system):
     param_dict, deterministic_dict = simple_param_system
 
-    f, _ = compile_param_dict_func(param_dict, deterministic_dict, backend=backend)
+    f, _ = compile_param_dict_func(param_dict, deterministic_dict)
     result = f(alpha=0.3, beta=0.99)
 
     assert isinstance(result, dict)
@@ -45,11 +44,10 @@ def test_compile_param_dict_basic(simple_param_system, backend):
     assert_allclose(result["gamma"], 0.3 + 0.99)
 
 
-@pytest.mark.parametrize("backend", ["numpy", "pytensor"])
-def test_compile_param_dict_complex(complex_param_system, backend):
+def test_compile_param_dict_complex(complex_param_system):
     param_dict, deterministic_dict = complex_param_system
 
-    f, _ = compile_param_dict_func(param_dict, deterministic_dict, backend=backend)
+    f, _ = compile_param_dict_func(param_dict, deterministic_dict)
     result = f(alpha=0.3, beta=0.99, theta=0.5)
 
     assert isinstance(result, dict)
@@ -59,16 +57,15 @@ def test_compile_param_dict_complex(complex_param_system, backend):
     assert_allclose(result["delta"], expected_gamma * 0.5)
 
 
-@pytest.mark.parametrize("backend", ["numpy", "pytensor"])
-def test_compile_param_dict_cache_reuse(complex_param_system, backend):
+def test_compile_param_dict_cache_reuse(complex_param_system):
     param_dict, deterministic_dict = complex_param_system
 
     # First compilation should create cache
     cache = {}
-    f1, cache = compile_param_dict_func(param_dict, deterministic_dict, backend=backend, cache=cache)
+    f1, cache = compile_param_dict_func(param_dict, deterministic_dict, cache=cache)
 
     # Second compilation should reuse cache
-    f2, cache2 = compile_param_dict_func(param_dict, deterministic_dict, backend=backend, cache=cache)
+    f2, cache2 = compile_param_dict_func(param_dict, deterministic_dict, cache=cache)
 
     # Results should be identical
     result1 = f1(alpha=0.3, beta=0.99, theta=0.5)
@@ -81,9 +78,7 @@ def test_compile_param_dict_cache_reuse(complex_param_system, backend):
 def test_compile_param_dict_symbolic(complex_param_system):
     param_dict, deterministic_dict = complex_param_system
 
-    symbolic_result, cache = compile_param_dict_func(
-        param_dict, deterministic_dict, backend="pytensor", return_symbolic=True
-    )
+    symbolic_result, cache = compile_param_dict_func(param_dict, deterministic_dict, return_symbolic=True)
 
     assert isinstance(symbolic_result, dict)
     assert isinstance(cache, dict)
@@ -115,8 +110,7 @@ EXPECTED_PARAM_DICT = {
     ],
     ids=["one_block_simple", "one_block_simple_2"],
 )
-@pytest.mark.parametrize("backend", ["numpy", "pytensor"], ids=["numpy", "pytensor"])
-def test_create_parameter_function(gcn_path, name, backend):
+def test_create_parameter_function(gcn_path, name):
     rng = np.random.default_rng()
     expected = EXPECTED_PARAM_DICT[name]
     filepath = Path("tests") / "_resources" / "test_gcns" / gcn_path
@@ -125,7 +119,7 @@ def test_create_parameter_function(gcn_path, name, backend):
     param_dict = _block_dict_to_param_dict(block_dict, "param_dict")
     deterministic_dict = _block_dict_to_param_dict(block_dict, "deterministic_dict")
 
-    f, _ = compile_param_dict_func(param_dict, deterministic_dict, backend)
+    f, _ = compile_param_dict_func(param_dict, deterministic_dict)
 
     inputs = list(param_dict.keys())
     rng.shuffle(inputs)

--- a/tests/model/test_statespace.py
+++ b/tests/model/test_statespace.py
@@ -22,7 +22,7 @@ from tests._resources.cache_compiled_models import (
 )
 def test_statespace_matrices_agree_with_model(gcn_file):
     ss_mod = load_and_cache_statespace(gcn_file)
-    model = load_and_cache_model(gcn_file, "numpy", use_jax=False)
+    model = load_and_cache_model(gcn_file)
 
     inputs = pm.inputvars(ss_mod.linearized_system)
     input_names = [x.name for x in inputs]

--- a/tests/model/test_steady_state.py
+++ b/tests/model/test_steady_state.py
@@ -12,7 +12,6 @@ from scipy import optimize
 from gEconpy.classes.containers import SymbolDictionary
 from gEconpy.classes.time_aware_symbol import TimeAwareSymbol
 from gEconpy.model.build import validate_results
-from gEconpy.model.compile import BACKENDS
 from gEconpy.model.model import Model
 from gEconpy.model.steady_state import (
     compile_model_ss_functions,
@@ -189,13 +188,13 @@ def root_and_min_agree_helper(model: Model, **kwargs):
 
 
 def test_solve_ss_with_partial_user_solution():
-    model_1 = load_and_cache_model("one_block_1.gcn", backend="numpy", use_jax=JAX_INSTALLED)
+    model_1 = load_and_cache_model("one_block_1.gcn")
     res = model_1.steady_state(verbose=False, progressbar=False)
     assert res.success
 
 
 def test_wrong_user_solutions_raises():
-    model_1 = load_and_cache_model("one_block_1.gcn", backend="numpy", use_jax=JAX_INSTALLED)
+    model_1 = load_and_cache_model("one_block_1.gcn")
 
     expected_msg = (
         "User-provide steady state is not valid. The following equations had non-zero residuals "
@@ -207,7 +206,7 @@ def test_wrong_user_solutions_raises():
 
 
 def test_print_steady_state_report_solver_successful(caplog):
-    model_1 = load_and_cache_model("one_block_1.gcn", backend="numpy", use_jax=JAX_INSTALLED)
+    model_1 = load_and_cache_model("one_block_1.gcn")
     res = model_1.steady_state(verbose=False, progressbar=False)
 
     expected_output = """A_ss               1.000
@@ -229,7 +228,7 @@ def test_print_steady_state_report_solver_successful(caplog):
 
 
 def test_print_steady_state_report_solver_fails(caplog):
-    model_1 = load_and_cache_model("one_block_1.gcn", backend="numpy", use_jax=JAX_INSTALLED)
+    model_1 = load_and_cache_model("one_block_1.gcn")
     result = model_1.steady_state(verbose=False, progressbar=False)
 
     # Spoof a failed solving attempt
@@ -252,7 +251,7 @@ def test_print_steady_state_report_solver_fails(caplog):
 
 
 def test_incomplete_ss_relationship_raises_with_root():
-    model_1 = load_and_cache_model("one_block_1.gcn", backend="numpy", use_jax=JAX_INSTALLED, infer_steady_state=False)
+    model_1 = load_and_cache_model("one_block_1.gcn", infer_steady_state=False)
     expected_msg = (
         'Solving a partially provided steady state with how = "root" is only allowed if applying the given '
         "values results in a new square system.\n"
@@ -266,18 +265,18 @@ def test_incomplete_ss_relationship_raises_with_root():
 
 
 def test_wrong_and_incomplete_ss_relationship_fails_with_minimize():
-    model_1 = load_and_cache_model("one_block_1.gcn", backend="numpy", use_jax=JAX_INSTALLED, infer_steady_state=False)
+    model_1 = load_and_cache_model("one_block_1.gcn", infer_steady_state=False)
     res = model_1.steady_state(verbose=False, progressbar=False, fixed_values={"K_ss": 3.0})
     assert not res.success
 
 
 def test_numerical_solvers_suceed_and_agree():
-    model_1 = load_and_cache_model("one_block_1.gcn", backend="numpy", use_jax=JAX_INSTALLED)
+    model_1 = load_and_cache_model("one_block_1.gcn")
     root_and_min_agree_helper(model_1, verbose=False, progressbar=False)
 
 
 def test_steady_state_matches_analytic():
-    model_1 = load_and_cache_model("one_block_1.gcn", backend="numpy", use_jax=JAX_INSTALLED)
+    model_1 = load_and_cache_model("one_block_1.gcn")
     param_dict = model_1.parameters().to_sympy()
     alpha, beta, delta, gamma, _rho = list(param_dict.keys())
 
@@ -304,8 +303,6 @@ def test_steady_state_matches_analytic():
 def test_numerical_solvers_succeed_and_agree_w_calibrated_params():
     model_2 = load_and_cache_model(
         "one_block_2_no_extra.gcn",
-        backend="pytensor",
-        use_jax=JAX_INSTALLED,
     )
     root_and_min_agree_helper(model_2, verbose=False, progressbar=False)
 
@@ -313,8 +310,6 @@ def test_numerical_solvers_succeed_and_agree_w_calibrated_params():
 def test_steady_state_matches_analytic_w_calibrated_params():
     model_2 = load_and_cache_model(
         "one_block_2_no_extra.gcn",
-        backend="pytensor",
-        use_jax=JAX_INSTALLED,
         infer_steady_state=True,
     )
     param_dict = model_2.parameters().to_sympy()
@@ -371,12 +366,12 @@ def test_steady_state_matches_analytic_w_calibrated_params():
 
 
 def test_numerical_solvers_succeed_and_agree_RBC():
-    model_3 = load_and_cache_model("rbc_2_block.gcn", backend="numpy", use_jax=JAX_INSTALLED)
+    model_3 = load_and_cache_model("rbc_2_block.gcn")
     root_and_min_agree_helper(model_3, verbose=False, progressbar=False)
 
 
 def test_RBC_steady_state_matches_analytic():
-    model_3 = load_and_cache_model("rbc_2_block.gcn", backend="numpy", use_jax=JAX_INSTALLED)
+    model_3 = load_and_cache_model("rbc_2_block.gcn")
     param_dict = model_3.parameters().to_sympy()
 
     alpha, beta, delta, _rho_A, sigma_C, sigma_L = list(param_dict.keys())
@@ -427,7 +422,7 @@ def test_RBC_steady_state_matches_analytic():
 
 @pytest.mark.include_nk
 def test_numerical_solvers_succeed_and_agree_NK():
-    model_4 = load_and_cache_model("full_nk_no_ss.gcn", backend="pytensor", use_jax=JAX_INSTALLED)
+    model_4 = load_and_cache_model("full_nk_no_ss.gcn")
 
     # This model's SS can't be solved without some help, so we provide the "obvious" solutions
     # This is almost equivalent to the full_nk_partial_ss.gcn, with a bit less info
@@ -449,7 +444,7 @@ def test_numerical_solvers_succeed_and_agree_NK():
 
 @pytest.mark.include_nk
 def test_steady_state_matches_analytic_NK():
-    model_4 = load_and_cache_model("full_nk_no_ss.gcn", backend="pytensor", use_jax=JAX_INSTALLED)
+    model_4 = load_and_cache_model("full_nk_no_ss.gcn")
 
     param_dict = model_4.parameters().to_sympy()
     (
@@ -569,11 +564,7 @@ def test_steady_state_matches_analytic_NK():
         assert_allclose(answer, numerical_ss_dict[k.name], err_msg=k.name)
 
 
-JAX_INSTALLED = find_spec("jax") is not None
-
-
-@pytest.mark.parametrize("backend", ["numpy", "pytensor"], ids=["numpy", "pytensor"])
-def test_all_model_functions_return_arrays(backend: BACKENDS):
+def test_all_model_functions_return_arrays():
     primitives = load_gcn_file("tests/_resources/test_gcns/one_block_1_ss.gcn", simplify_blocks=True)
 
     equations = primitives.equations
@@ -593,9 +584,6 @@ def test_all_model_functions_return_arrays(backend: BACKENDS):
     )
     steady_state_equations = system_to_steady_state(equations, shocks)
 
-    kwargs = {}
-    if backend == "pytensor":
-        kwargs["mode"] = "JAX" if JAX_INSTALLED else "FAST_RUN"
     (f_params, f_ss, resid_funcs, error_funcs), _cache = compile_model_ss_functions(
         steady_state_equations,
         ss_solution_dict,
@@ -604,8 +592,6 @@ def test_all_model_functions_return_arrays(backend: BACKENDS):
         deterministic_dict,
         calib_dict,
         error_func="squared",
-        backend=backend,
-        **kwargs,
     )
 
     f_ss_resid, f_ss_jac = resid_funcs

--- a/tests/pytensorf/test_compile.py
+++ b/tests/pytensorf/test_compile.py
@@ -1,0 +1,67 @@
+import numpy as np
+import pytensor.tensor as pt
+import pytest
+
+from pytensor.graph.replace import graph_replace
+
+from gEconpy.pytensorf.compile import (
+    clear_compile_cache,
+    compile_cache_info,
+    compile_pytensor_function,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    """Ensure each test starts with a fresh compile cache."""
+    clear_compile_cache()
+    yield
+    clear_compile_cache()
+
+
+def test_cache_hits():
+    x = pt.dscalar("x")
+    z = x**2
+
+    f1 = compile_pytensor_function([x], [z], mode="FAST_COMPILE")
+    f2 = compile_pytensor_function([x], [z], mode="FAST_COMPILE")
+
+    assert f1 is f2
+    assert compile_cache_info().hits >= 1
+
+
+def test_cache_miss_different_mode():
+    x = pt.dscalar("x")
+    z = x**2
+
+    f1 = compile_pytensor_function([x], [z], mode="FAST_COMPILE")
+    f2 = compile_pytensor_function([x], [z], mode="FAST_RUN")
+
+    assert f1 is not f2
+
+
+def test_cache_miss_after_graph_replace():
+    x = pt.dscalar("x")
+    y = pt.dscalar("y")
+    z = x + y
+
+    f1 = compile_pytensor_function([x, y], [z], mode="FAST_COMPILE")
+
+    z2 = graph_replace(z, {x: pt.exp(x)})
+    f2 = compile_pytensor_function([x, y], [z2], mode="FAST_COMPILE")
+
+    assert f1 is not f2
+
+    np.testing.assert_allclose(f1(np.float64(1.0), np.float64(2.0)), [3.0])
+    np.testing.assert_allclose(f2(np.float64(1.0), np.float64(2.0)), [np.exp(1.0) + 2.0])
+
+
+def test_clear_cache():
+    x = pt.dscalar("x")
+    z = x**2
+
+    compile_pytensor_function([x], [z], mode="FAST_COMPILE")
+    assert compile_cache_info().currsize == 1
+
+    clear_compile_cache()
+    assert compile_cache_info().currsize == 0

--- a/tests/solvers/test_backward_looking.py
+++ b/tests/solvers/test_backward_looking.py
@@ -15,7 +15,7 @@ from tests._resources.cache_compiled_models import load_and_cache_model
 
 @pytest.fixture(scope="module")
 def sarima_model():
-    return load_and_cache_model("sarima2_12.gcn", backend="numpy")
+    return load_and_cache_model("sarima2_12.gcn")
 
 
 @pytest.fixture(scope="module")
@@ -29,11 +29,11 @@ class TestBackwardLookingDetection:
         assert sarima_model._backward_looking
 
     def test_forward_looking_model_is_not_backward_looking(self):
-        model = load_and_cache_model("one_block_1.gcn", backend="numpy")
+        model = load_and_cache_model("one_block_1.gcn")
         assert not model._backward_looking
 
     def test_backward_direct_rejects_forward_looking_model(self):
-        model = load_and_cache_model("one_block_1.gcn", backend="numpy")
+        model = load_and_cache_model("one_block_1.gcn")
         with pytest.raises(ValueError, match="backward_direct"):
             model.solve_model(solver="backward_direct", verbose=False)
 

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -62,7 +62,7 @@ class TestUtilities(unittest.TestCase):
 class TestPlotSimulation(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.model = load_and_cache_model("rbc_linearized.gcn", backend="numpy")
+        cls.model = load_and_cache_model("rbc_linearized.gcn")
         cls.data = simulate(
             cls.model,
             simulation_length=100,
@@ -108,7 +108,7 @@ class TestPlotSimulation(unittest.TestCase):
 
 @pytest.fixture(scope="session")
 def irf_setup():
-    model = load_and_cache_model("full_nk.gcn", backend="numpy")
+    model = load_and_cache_model("full_nk.gcn")
     model.steady_state(verbose=False)
     T, R = model.solve_model(verbose=False, solver="gensys")
     irf = impulse_response_function(
@@ -187,7 +187,7 @@ def test_plot_irf_legend(irf_setup):
 class TestPlotEigenvalues(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
-        cls.model = load_and_cache_model("one_block_1.gcn", backend="numpy")
+        cls.model = load_and_cache_model("one_block_1.gcn")
 
     def test_plot_with_defaults(self):
         fig = plot_eigenvalues(
@@ -228,7 +228,7 @@ class TestPlotEigenvalues(unittest.TestCase):
 class TestPlotCovarianceMatrix(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
-        cls.model = load_and_cache_model("one_block_1.gcn", backend="numpy")
+        cls.model = load_and_cache_model("one_block_1.gcn")
 
         cls.cov_matrix = stationary_covariance_matrix(
             cls.model,
@@ -262,7 +262,7 @@ class TestPlotCovarianceMatrix(unittest.TestCase):
 class TestPlotACF(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
-        cls.model = load_and_cache_model("one_block_1.gcn", backend="numpy")
+        cls.model = load_and_cache_model("one_block_1.gcn")
 
         cls.acf = autocorrelation_matrix(
             cls.model,


### PR DESCRIPTION
Part 1 of a series of commits going all-in on pytensor. 

Step 1 removes the public API to the numpy "backend" (compiling functions using sp.lambdify). Backend tests are also removed.

I added a caching compiler helper as well.

<!-- readthedocs-preview gEconpy start -->
----
📚 Documentation preview 📚: https://gEconpy--70.org.readthedocs.build/en/70/

<!-- readthedocs-preview gEconpy end -->