### PR TITLE
Perfect Foresight Improvements

### DIFF
--- a/conda_envs/environment.yml
+++ b/conda_envs/environment.yml
@@ -18,7 +18,7 @@ dependencies:
   - preliz>=0.23.0
   - sympy>=1.14.0
   - pymc-extras>=0.8.0
-  - better-optimize
+  - better-optimize>=0.2.1
   - preliz
   - ipython
   - nutpie

--- a/conda_envs/environment_dev.yml
+++ b/conda_envs/environment_dev.yml
@@ -42,6 +42,7 @@ dependencies:
   - sphinxcontrib-bibtex
   - pydata-sphinx-theme
   - watermark
+  - better-optimize>=0.2.1
 
   # developer tools
   - pre-commit

--- a/conda_envs/environment_docs.yml
+++ b/conda_envs/environment_docs.yml
@@ -19,7 +19,7 @@ dependencies:
   - preliz>=0.23.0
   - sympy>=1.14.0
   - pymc-extras>=0.8.0
-  - better-optimize
+  - better-optimize>=0.2.1
   - sympytensor>=1.4.1
   - jax
   - nutpie

--- a/conda_envs/geconpy_test.yml
+++ b/conda_envs/geconpy_test.yml
@@ -20,7 +20,7 @@ dependencies:
   - ipython
   - sympytensor>=1.4.1
   - pymc-extras>=0.8.0
-  - better-optimize
+  - better-optimize>=0.2.1
   - nutpie
   - networkx
 

--- a/gEconpy/model/perfect_foresight/__init__.py
+++ b/gEconpy/model/perfect_foresight/__init__.py
@@ -2,10 +2,11 @@ from gEconpy.model.perfect_foresight.compile import (
     PerfectForesightProblem,
     compile_perfect_foresight_problem,
 )
-from gEconpy.model.perfect_foresight.solve import solve_perfect_foresight
+from gEconpy.model.perfect_foresight.solve import make_piecewise_x0, solve_perfect_foresight
 
 __all__ = [
     "PerfectForesightProblem",
     "compile_perfect_foresight_problem",
+    "make_piecewise_x0",
     "solve_perfect_foresight",
 ]

--- a/gEconpy/model/perfect_foresight/assemble.py
+++ b/gEconpy/model/perfect_foresight/assemble.py
@@ -31,9 +31,20 @@ def assemble_stacked_jacobian(
     sparse.csc_matrix
         Block-tridiagonal sparse Jacobian of shape (T*n_eq, T*n_vars).
     """
-    rows: list[int] = []
-    cols: list[int] = []
-    data: list[float] = []
+    # Count total non-zeros across all blocks to pre-allocate
+    total_nnz = 0
+    for t in range(T):
+        J = period_jacobians[t]
+        total_nnz += np.count_nonzero(J[:, n_vars : 2 * n_vars])  # J_t (always present)
+        if t > 0:
+            total_nnz += np.count_nonzero(J[:, :n_vars])  # J_{t-1}
+        if t < T - 1:
+            total_nnz += np.count_nonzero(J[:, 2 * n_vars : 3 * n_vars])  # J_{t+1}
+
+    rows = np.empty(total_nnz, dtype=np.intp)
+    cols = np.empty(total_nnz, dtype=np.intp)
+    data = np.empty(total_nnz)
+    pos = 0
 
     for t in range(T):
         J_period = period_jacobians[t]
@@ -43,27 +54,30 @@ def assemble_stacked_jacobian(
         J_t = J_period[:, n_vars : 2 * n_vars]
         J_tp1 = J_period[:, 2 * n_vars : 3 * n_vars]
 
-        # J^{-1} block (skip at t=0, initial condition is fixed)
         if t > 0:
             col_offset = (t - 1) * n_vars
             r, c = np.nonzero(J_tm1)
-            rows.extend(row_offset + r)
-            cols.extend(col_offset + c)
-            data.extend(J_tm1[r, c])
+            n = len(r)
+            rows[pos : pos + n] = row_offset + r
+            cols[pos : pos + n] = col_offset + c
+            data[pos : pos + n] = J_tm1[r, c]
+            pos += n
 
-        # J^{0} block
         col_offset = t * n_vars
         r, c = np.nonzero(J_t)
-        rows.extend(row_offset + r)
-        cols.extend(col_offset + c)
-        data.extend(J_t[r, c])
+        n = len(r)
+        rows[pos : pos + n] = row_offset + r
+        cols[pos : pos + n] = col_offset + c
+        data[pos : pos + n] = J_t[r, c]
+        pos += n
 
-        # J^{+1} block (skip at t=T-1, terminal condition is fixed)
         if t < T - 1:
             col_offset = (t + 1) * n_vars
             r, c = np.nonzero(J_tp1)
-            rows.extend(row_offset + r)
-            cols.extend(col_offset + c)
-            data.extend(J_tp1[r, c])
+            n = len(r)
+            rows[pos : pos + n] = row_offset + r
+            cols[pos : pos + n] = col_offset + c
+            data[pos : pos + n] = J_tp1[r, c]
+            pos += n
 
     return sparse.csc_matrix((data, (rows, cols)), shape=(T * n_eq, T * n_vars))

--- a/gEconpy/model/perfect_foresight/solve.py
+++ b/gEconpy/model/perfect_foresight/solve.py
@@ -51,12 +51,48 @@ def _build_shock_matrix(
     return shock_matrix
 
 
+def _build_param_matrix(
+    param_paths: dict[str, float | np.ndarray] | None,
+    param_names: list[str],
+    param_defaults: dict[str, float],
+    T: int,
+) -> np.ndarray:
+    """Construct (T, n_params) parameter matrix from defaults and user-specified paths.
+
+    Parameters
+    ----------
+    param_paths : dict or None
+        Parameter paths. Values are either a scalar (constant across all periods) or an array of length T
+        (time-varying).
+    param_names : list of str
+        Ordered parameter names from the compiled problem.
+    param_defaults : dict of str to float
+        Default parameter values from the model.
+    T : int
+        Number of time periods.
+
+    Returns
+    -------
+    ndarray
+        Parameter matrix of shape (T, n_params).
+    """
+    defaults = np.array([param_defaults[name] for name in param_names])
+    param_matrix = np.tile(defaults, (T, 1))
+
+    if param_paths:
+        for name, value in param_paths.items():
+            idx = param_names.index(name)
+            param_matrix[:, idx] = value
+
+    return param_matrix
+
+
 def _compute_stacked_residuals_and_jacobian(
     y: np.ndarray,
     y_initial: np.ndarray,
     y_terminal: np.ndarray,
     x: np.ndarray,
-    params: tuple,
+    params: np.ndarray,
     problem: PerfectForesightProblem,
 ) -> tuple[np.ndarray, sparse.csc_matrix]:
     """Evaluate the single-period function T times and assemble the stacked system."""
@@ -70,19 +106,16 @@ def _compute_stacked_residuals_and_jacobian(
     jacobians = []
 
     for t in range(T):
-        # Get y_{t-1}, y_t, y_{t+1}
         y_tm1 = y_initial if t == 0 else y_mat[t - 1]
         y_t = y_mat[t]
         y_tp1 = y_terminal if t == T - 1 else y_mat[t + 1]
 
-        # Get shocks for this period
         x_t = x[t] if n_shocks > 0 else np.array([])
 
-        # Call the compiled function
         if n_shocks > 0:
-            r, J = problem.f_resid_and_jac(y_tm1, y_t, y_tp1, x_t, *params)
+            r, J = problem.f_resid_and_jac(y_tm1, y_t, y_tp1, x_t, *params[t])
         else:
-            r, J = problem.f_resid_and_jac(y_tm1, y_t, y_tp1, *params)
+            r, J = problem.f_resid_and_jac(y_tm1, y_t, y_tp1, *params[t])
 
         residuals[t * n_eq : (t + 1) * n_eq] = r
         jacobians.append(J)
@@ -98,14 +131,122 @@ def _build_trajectory_dataframe(x: np.ndarray, var_names: list[str], T: int) -> 
     return pd.DataFrame(data, index=range(T), columns=var_names)
 
 
+def _normalize_condition_keys(conditions: dict[str, float]) -> dict[str, float]:
+    """Strip the ``_ss`` suffix from condition keys so that steady-state dictionaries can be used directly.
+
+    Accepts both ``"K"`` and ``"K_ss"`` as keys; the returned dict always uses base names.
+    """
+    return {k.removesuffix("_ss"): v for k, v in conditions.items()}
+
+
+def _ss_dict_to_array(ss_dict: dict[str, float], var_names: list[str]) -> np.ndarray:
+    """Extract a 1-d array of steady-state values in ``var_names`` order from a dict with ``_ss``-suffixed keys."""
+    return np.array([ss_dict.get(f"{name}_ss", ss_dict.get(name, 1.0)) for name in var_names])
+
+
+def _infer_var_names_from_ss(*ss_dicts: dict[str, float]) -> list[str]:
+    """Infer variable base names from one or more steady-state dictionaries.
+
+    Takes the union of keys across all dicts, strips the ``_ss`` suffix, and returns a sorted list.
+    """
+    names: set[str] = set()
+    for d in ss_dicts:
+        names.update(k.removesuffix("_ss") for k in d)
+    return sorted(names)
+
+
+def make_piecewise_x0(
+    initial_ss: dict[str, float],
+    terminal_ss: dict[str, float],
+    simulation_length: int,
+    var_names: list[str] | None = None,
+    transition_start: int | None = None,
+    transition_periods: int = 1,
+) -> pd.DataFrame:
+    """Build an initial guess that transitions between two steady states.
+
+    Parameters
+    ----------
+    initial_ss : dict
+        Steady-state dictionary for the initial regime (keys may have ``_ss`` suffix).
+    terminal_ss : dict
+        Steady-state dictionary for the terminal regime.
+    simulation_length : int
+        Total number of periods.
+    var_names : list of str, optional
+        Variable names and their order. If not provided, names are inferred from the union of keys in
+        ``initial_ss`` and ``terminal_ss`` (with ``_ss`` suffix stripped), sorted alphabetically.
+    transition_start : int, optional
+        Period index where the transition begins. Defaults to ``simulation_length // 2``.
+    transition_periods : int, default 1
+        Number of periods over which to linearly interpolate. Set to 1 for a step change; larger values produce
+        a smoother initial guess that can improve convergence for large permanent shocks.
+
+    Returns
+    -------
+    DataFrame
+        Shape ``(simulation_length, n_vars)`` with variable names as columns.
+    """
+    if var_names is None:
+        var_names = _infer_var_names_from_ss(initial_ss, terminal_ss)
+
+    if transition_start is None:
+        transition_start = simulation_length // 2
+
+    init_vals = _ss_dict_to_array(initial_ss, var_names)
+    term_vals = _ss_dict_to_array(terminal_ss, var_names)
+
+    x0 = np.empty((simulation_length, len(var_names)))
+    transition_end = min(transition_start + transition_periods, simulation_length)
+
+    x0[:transition_start] = init_vals
+    x0[transition_end:] = term_vals
+
+    if transition_end > transition_start:
+        n = transition_end - transition_start
+        if n == 1:
+            x0[transition_start] = term_vals
+        else:
+            weights = np.linspace(0, 1, n)[:, None]
+            x0[transition_start:transition_end] = (1 - weights) * init_vals + weights * term_vals
+
+    return pd.DataFrame(x0, columns=var_names)
+
+
+def _extract_boundary_param_kwargs(
+    param_paths: dict[str, float | np.ndarray] | None,
+) -> tuple[dict[str, float], dict[str, float]]:
+    """Extract parameter values at t=0 and t=T-1 from param_paths for steady-state computation.
+
+    Returns two dicts suitable for passing as ``**kwargs`` to ``model.steady_state()``.
+    """
+    if not param_paths:
+        return {}, {}
+
+    initial_kwargs = {}
+    terminal_kwargs = {}
+    for name, value in param_paths.items():
+        if isinstance(value, np.ndarray):
+            initial_kwargs[name] = float(value[0])
+            terminal_kwargs[name] = float(value[-1])
+        else:
+            initial_kwargs[name] = float(value)
+            terminal_kwargs[name] = float(value)
+
+    return initial_kwargs, terminal_kwargs
+
+
 def solve_perfect_foresight(
     model: "Model",
     simulation_length: int,
+    x0: np.ndarray | pd.DataFrame | dict[str, float] | None = None,
     initial_conditions: dict[str, float] | None = None,
     terminal_conditions: dict[str, float] | None = None,
     shocks: dict[str, np.ndarray] | None = None,
+    param_paths: dict[str, float | np.ndarray] | None = None,
     compile_kwargs: dict | None = None,
     optimize_kwargs: dict | None = None,
+    steady_state_kwargs: dict | None = None,
 ) -> tuple[pd.DataFrame, OptimizeResult]:
     """Solve the model under perfect foresight.
 
@@ -115,19 +256,38 @@ def solve_perfect_foresight(
         The DSGE model to solve.
     simulation_length : int
         Number of time periods for the simulation.
+    x0 : DataFrame, ndarray, dict, or None, optional
+        Initial guess for the Newton solver. Accepts four forms:
+
+        - ``None`` (default): compute the steady state and tile it across all periods.
+        - ``dict``: a steady-state dictionary (as returned by ``model.steady_state()``). Used in place of
+          calling ``model.steady_state()`` internally, and also used for default initial/terminal conditions.
+        - ``DataFrame``: columns are variable names, rows are periods. Columns are reindexed to match the
+          model's canonical variable order. This is the output format of :func:`make_piecewise_x0`.
+        - ``ndarray`` of shape ``(simulation_length, n_vars)``: a full initial trajectory. Columns must be in
+          the model's canonical variable order.
     initial_conditions : dict of str to float, optional
-        Initial values for state variables at t=-1. Keys are variable base names.
-        If not provided, steady state values are used.
+        Initial values for state variables at t=-1. Keys are variable base names (e.g., ``"K"``). Keys with an
+        ``_ss`` suffix (e.g., ``"K_ss"``) are also accepted. If not provided, steady-state values are used.
     terminal_conditions : dict of str to float, optional
-        Terminal values for state variables at t=T. Keys are variable base names.
-        If not provided, steady state values are used.
+        Terminal values for state variables at t=T. Keys are variable base names (e.g., ``"K"``). Keys with an
+        ``_ss`` suffix are also accepted. If not provided, steady-state values are used.
     shocks : dict of str to ndarray, optional
-        Shock paths over the simulation horizon. Keys are shock base names,
-        values are arrays of length T. If None, all shocks are set to zero.
+        Shock paths over the simulation horizon. Keys are shock base names, values are arrays of length T. If
+        None, all shocks are set to zero.
+    param_paths : dict of str to float or ndarray, optional
+        Parameter paths over the simulation horizon, analogous to ``shocks``. Keys are parameter names. Values
+        are either a scalar (constant across all periods) or an array of length T (time-varying). Parameters not
+        listed use their current model values. When time-varying paths are provided and boundary conditions are
+        not fully specified, the steady state for initial/terminal conditions is computed using the parameter
+        values at t=0 and t=T-1 respectively.
     compile_kwargs : dict, optional
-        Additional arguments passed to pytensor.function when compiling.
+        Additional arguments passed to ``pytensor.function`` when compiling.
     optimize_kwargs : dict, optional
-        Additional arguments passed to sparse_newton when solving.
+        Additional arguments passed to ``sparse_newton`` when solving.
+    steady_state_kwargs : dict, optional
+        Additional arguments passed to ``model.steady_state()``. If ``'verbose'`` is not explicitly set, it
+        defaults to ``False``.
 
     Returns
     -------
@@ -138,6 +298,8 @@ def solve_perfect_foresight(
 
     Examples
     --------
+    Temporary shock (transition from perturbed initial condition back to steady state):
+
     .. code-block:: python
 
         from gEconpy.model import load_gcn
@@ -151,41 +313,114 @@ def solve_perfect_foresight(
             simulation_length=100,
             initial_conditions={"K": ss_dict["K_ss"] * 0.9},
         )
-        trajectory.plot()
+
+    Permanent shock (transition between two steady states):
+
+    .. code-block:: python
+
+        from gEconpy.model.perfect_foresight import make_piecewise_x0
+        import numpy as np
+
+        init_ss = model.steady_state(tax_rate=0.08, how="root")
+        final_ss = model.steady_state(tax_rate=0.18, how="root")
+
+        x0 = make_piecewise_x0(init_ss, final_ss, simulation_length=200, transition_periods=50)
+        tax_path = np.where(np.arange(200) < 100, 0.08, 0.18)
+
+        trajectory, result = solve_perfect_foresight(
+            model,
+            simulation_length=200,
+            x0=x0,
+            initial_conditions=init_ss,
+            terminal_conditions=final_ss,
+            param_paths={"tax_rate": tax_path},
+        )
     """
-    initial_conditions = initial_conditions or {}
-    terminal_conditions = terminal_conditions or {}
+    initial_conditions = _normalize_condition_keys(initial_conditions or {})
+    terminal_conditions = _normalize_condition_keys(terminal_conditions or {})
     compile_kwargs = compile_kwargs or {}
     optimize_kwargs = optimize_kwargs or {}
+    steady_state_kwargs = steady_state_kwargs or {}
+    steady_state_kwargs.setdefault("verbose", False)
 
     problem = compile_perfect_foresight_problem(model, simulation_length, **compile_kwargs)
-    ss_dict = model.steady_state(verbose=False)
-
     var_names = problem.var_names
+    n_vars = len(var_names)
+    var_set = set(var_names)
+
+    conditions_complete = var_set <= initial_conditions.keys() and var_set <= terminal_conditions.keys()
+    init_param_kwargs, term_param_kwargs = _extract_boundary_param_kwargs(param_paths)
+
+    needs_initial_ss = not (var_set <= initial_conditions.keys())
+    needs_terminal_ss = not (var_set <= terminal_conditions.keys())
+
+    def _compute_ss(**extra_kwargs):
+        return model.steady_state(**steady_state_kwargs, **extra_kwargs)
+
+    if isinstance(x0, dict):
+        init_ss_dict = x0
+        term_ss_dict = x0
+        x0_vec = np.tile(_ss_dict_to_array(init_ss_dict, var_names), simulation_length)
+    elif isinstance(x0, pd.DataFrame):
+        if len(x0) != simulation_length:
+            raise ValueError(f"x0 DataFrame must have {simulation_length} rows, got {len(x0)}")
+        x0_vec = x0.reindex(columns=var_names).to_numpy().ravel()
+        init_ss_dict = _compute_ss(**init_param_kwargs) if needs_initial_ss else None
+        term_ss_dict = (
+            _compute_ss(**term_param_kwargs)
+            if needs_terminal_ss and term_param_kwargs != init_param_kwargs
+            else init_ss_dict
+        )
+    elif isinstance(x0, np.ndarray):
+        if x0.shape != (simulation_length, n_vars):
+            raise ValueError(f"x0 array must have shape ({simulation_length}, {n_vars}), got {x0.shape}")
+        x0_vec = x0.ravel()
+        init_ss_dict = _compute_ss(**init_param_kwargs) if needs_initial_ss else None
+        term_ss_dict = (
+            _compute_ss(**term_param_kwargs)
+            if needs_terminal_ss and term_param_kwargs != init_param_kwargs
+            else init_ss_dict
+        )
+    else:
+        init_ss_dict = _compute_ss(**init_param_kwargs)
+        term_ss_dict = _compute_ss(**term_param_kwargs) if term_param_kwargs != init_param_kwargs else init_ss_dict
+        x0_vec = np.tile(_ss_dict_to_array(init_ss_dict, var_names), simulation_length)
 
     validate_perfect_foresight_inputs(
         initial_conditions,
         terminal_conditions,
         shocks,
+        param_paths,
         var_names,
         problem.shock_names,
+        problem.param_names,
         simulation_length,
     )
 
-    x0 = np.tile([ss_dict.get(f"{name}_ss", 1.0) for name in var_names], simulation_length)
-
-    y_initial = np.array([initial_conditions.get(name, ss_dict.get(f"{name}_ss", 1.0)) for name in var_names])
-    y_terminal = np.array([terminal_conditions.get(name, ss_dict.get(f"{name}_ss", 1.0)) for name in var_names])
+    if conditions_complete:
+        y_initial = np.array([initial_conditions[name] for name in var_names])
+        y_terminal = np.array([terminal_conditions[name] for name in var_names])
+    else:
+        y_initial = _ss_dict_to_array(init_ss_dict, var_names)
+        for name, val in initial_conditions.items():
+            idx = var_names.index(name)
+            y_initial[idx] = val
+        y_terminal = _ss_dict_to_array(term_ss_dict, var_names)
+        for name, val in terminal_conditions.items():
+            idx = var_names.index(name)
+            y_terminal[idx] = val
 
     shock_matrix = _build_shock_matrix(shocks, problem.shock_names, simulation_length)
 
     param_dict = model.parameters()
-    params = tuple(param_dict[name] for name in problem.param_names)
+    param_matrix = _build_param_matrix(param_paths, problem.param_names, param_dict, simulation_length)
 
     def system(x, y_init, y_term, shock_mat, param_vals, prob):
         return _compute_stacked_residuals_and_jacobian(x, y_init, y_term, shock_mat, param_vals, prob)
 
-    result = sparse_newton(system, x0, args=(y_initial, y_terminal, shock_matrix, params, problem), **optimize_kwargs)
+    result = sparse_newton(
+        system, x0_vec, args=(y_initial, y_terminal, shock_matrix, param_matrix, problem), **optimize_kwargs
+    )
 
     trajectory = _build_trajectory_dataframe(result.x, var_names, simulation_length)
     return trajectory, result

--- a/gEconpy/model/perfect_foresight/solve.py
+++ b/gEconpy/model/perfect_foresight/solve.py
@@ -302,9 +302,9 @@ def solve_perfect_foresight(
 
     .. code-block:: python
 
-        from gEconpy.model import load_gcn
+        import gEconpy as ge
 
-        model = load_gcn("rbc.gcn")
+        model = ge.model_from_gcn("rbc.gcn")
         ss_dict = model.steady_state()
 
         # Simulate transition from 90% of steady state capital

--- a/gEconpy/model/perfect_foresight/solve.py
+++ b/gEconpy/model/perfect_foresight/solve.py
@@ -348,7 +348,6 @@ def solve_perfect_foresight(
     n_vars = len(var_names)
     var_set = set(var_names)
 
-    conditions_complete = var_set <= initial_conditions.keys() and var_set <= terminal_conditions.keys()
     init_param_kwargs, term_param_kwargs = _extract_boundary_param_kwargs(param_paths)
 
     needs_initial_ss = not (var_set <= initial_conditions.keys())
@@ -366,21 +365,27 @@ def solve_perfect_foresight(
             raise ValueError(f"x0 DataFrame must have {simulation_length} rows, got {len(x0)}")
         x0_vec = x0.reindex(columns=var_names).to_numpy().ravel()
         init_ss_dict = _compute_ss(**init_param_kwargs) if needs_initial_ss else None
-        term_ss_dict = (
-            _compute_ss(**term_param_kwargs)
-            if needs_terminal_ss and term_param_kwargs != init_param_kwargs
-            else init_ss_dict
-        )
+        if needs_terminal_ss:
+            term_ss_dict = (
+                init_ss_dict
+                if init_ss_dict is not None and term_param_kwargs == init_param_kwargs
+                else _compute_ss(**term_param_kwargs)
+            )
+        else:
+            term_ss_dict = None
     elif isinstance(x0, np.ndarray):
         if x0.shape != (simulation_length, n_vars):
             raise ValueError(f"x0 array must have shape ({simulation_length}, {n_vars}), got {x0.shape}")
         x0_vec = x0.ravel()
         init_ss_dict = _compute_ss(**init_param_kwargs) if needs_initial_ss else None
-        term_ss_dict = (
-            _compute_ss(**term_param_kwargs)
-            if needs_terminal_ss and term_param_kwargs != init_param_kwargs
-            else init_ss_dict
-        )
+        if needs_terminal_ss:
+            term_ss_dict = (
+                init_ss_dict
+                if init_ss_dict is not None and term_param_kwargs == init_param_kwargs
+                else _compute_ss(**term_param_kwargs)
+            )
+        else:
+            term_ss_dict = None
     else:
         init_ss_dict = _compute_ss(**init_param_kwargs)
         term_ss_dict = _compute_ss(**term_param_kwargs) if term_param_kwargs != init_param_kwargs else init_ss_dict
@@ -397,14 +402,17 @@ def solve_perfect_foresight(
         simulation_length,
     )
 
-    if conditions_complete:
+    if not needs_initial_ss:
         y_initial = np.array([initial_conditions[name] for name in var_names])
-        y_terminal = np.array([terminal_conditions[name] for name in var_names])
     else:
         y_initial = _ss_dict_to_array(init_ss_dict, var_names)
         for name, val in initial_conditions.items():
             idx = var_names.index(name)
             y_initial[idx] = val
+
+    if not needs_terminal_ss:
+        y_terminal = np.array([terminal_conditions[name] for name in var_names])
+    else:
         y_terminal = _ss_dict_to_array(term_ss_dict, var_names)
         for name, val in terminal_conditions.items():
             idx = var_names.index(name)

--- a/gEconpy/model/perfect_foresight/validation.py
+++ b/gEconpy/model/perfect_foresight/validation.py
@@ -5,8 +5,10 @@ def validate_perfect_foresight_inputs(
     initial_conditions: dict[str, float],
     terminal_conditions: dict[str, float],
     shocks: dict[str, np.ndarray] | None,
+    param_paths: dict[str, float | np.ndarray] | None,
     var_names: list[str],
     shock_names: list[str],
+    param_names: list[str],
     simulation_length: int,
 ) -> None:
     """Validate inputs to solve_perfect_foresight.
@@ -19,20 +21,20 @@ def validate_perfect_foresight_inputs(
         Terminal values for state variables at t=T.
     shocks : dict of str to ndarray or None
         Shock paths over the simulation horizon.
+    param_paths : dict of str to float or ndarray, or None
+        Parameter overrides (scalar or time-varying).
     var_names : list of str
         Valid variable names from the model.
     shock_names : list of str
         Valid shock names from the model.
+    param_names : list of str
+        Valid parameter names from the model.
     simulation_length : int
         Number of time periods.
-
-    Raises
-    ------
-    ValueError
-        If any input contains invalid variable/shock names or incorrect dimensions.
     """
     var_set = set(var_names)
     shock_set = set(shock_names)
+    param_set = set(param_names)
 
     invalid_initial = set(initial_conditions.keys()) - var_set
     if invalid_initial:
@@ -50,3 +52,12 @@ def validate_perfect_foresight_inputs(
         for name, values in shocks.items():
             if len(values) != simulation_length:
                 raise ValueError(f"Shock '{name}' has length {len(values)}, expected {simulation_length}")
+
+    if param_paths:
+        invalid_params = set(param_paths.keys()) - param_set
+        if invalid_params:
+            raise ValueError(f"Unknown parameters in param_paths: {invalid_params}. Valid: {param_names}")
+
+        for name, value in param_paths.items():
+            if isinstance(value, np.ndarray) and len(value) != simulation_length:
+                raise ValueError(f"param_paths['{name}'] has length {len(value)}, expected {simulation_length}")

--- a/gEconpy/pytensorf/sparse_jacobian.py
+++ b/gEconpy/pytensorf/sparse_jacobian.py
@@ -83,7 +83,7 @@ def _greedy_color(
     ValueError
         If connectivity is not a square 2D matrix.
     """
-    is_2d = connectivity.ndim == 2  # noqa: PLR2004
+    is_2d = connectivity.ndim == 2
     is_square = connectivity.shape[0] == connectivity.shape[1]
     if not (is_2d and is_square):
         raise ValueError(f"Expected square 2D connectivity matrix, got shape {connectivity.shape}")

--- a/gEconpy/solvers/gensys.py
+++ b/gEconpy/solvers/gensys.py
@@ -206,7 +206,7 @@ def qzdiv(
         m = None
         for j in range(i, -1, -1):
             # No idea why -0.1 appears here; it comes from the original MATLAB code.
-            if (root[j, 1] > stake) or (root[j, 1] < -0.1):  # noqa: PLR2004
+            if (root[j, 1] > stake) or (root[j, 1] < -0.1):
                 m = j
                 break
 

--- a/gEconpy/solvers/sparse_newton.py
+++ b/gEconpy/solvers/sparse_newton.py
@@ -6,13 +6,13 @@ import numpy as np
 from better_optimize.wrapper import ObjectiveWrapper, optimizer_early_stopping_wrapper
 from scipy import sparse
 from scipy.optimize import OptimizeResult
+from scipy.sparse.linalg import spsolve
 
 
 def _validate_fused_fun(fun: Callable, x0: np.ndarray, args: tuple) -> None:
     """Validate that fun returns (residuals, sparse_jacobian)."""
     test_result = fun(x0, *args)
-    n_expected_outputs = 2
-    if not (isinstance(test_result, tuple) and len(test_result) == n_expected_outputs):
+    if not (isinstance(test_result, tuple) and len(test_result) == 2):
         raise ValueError("fun must return a tuple of (residuals, jacobian)")
 
     res, jac = test_result
@@ -22,49 +22,131 @@ def _validate_fused_fun(fun: Callable, x0: np.ndarray, args: tuple) -> None:
         raise TypeError("fun must return a sparse jacobian")
 
 
+def _check_convergence(dx: np.ndarray, x_new: np.ndarray, tol: float) -> bool:
+    return np.max(np.abs(dx)) < tol * (1.0 + np.max(np.abs(x_new)))
+
+
+def _phi(res: np.ndarray) -> float:
+    """Merit function for line search: 0.5 * ||res||^2."""
+    return 0.5 * np.dot(res, res)
+
+
+def _solve_newton_step(jac: sparse.spmatrix, res: np.ndarray, solver: Callable | None) -> tuple[np.ndarray, bool]:
+    """Compute the Newton step dx = -J^{-1} F(x).
+
+    Uses ``spsolve`` by default, or delegates to a caller-provided linear solver. Returns ``(dx, True)`` on success,
+    or ``(steepest_descent_direction, False)`` on failure.
+    """
+    try:
+        dx = spsolve(jac, -res) if solver is None else solver(jac, -res)
+
+        if np.all(np.isfinite(dx)):
+            return dx, True
+
+    except Exception:
+        pass
+
+    return -(jac.T @ res), False
+
+
 def _sparse_newton_core(
     fun: Callable,
     x0: np.ndarray,
     args: tuple = (),
-    tol: float = 1e-10,
+    f_tol: float = 1e-10,
+    x_tol: float = 1e-10,
+    max_ls: int = 50,
+    beta: float = 0.5,
+    c1: float = 1e-4,
     maxiter: int = 100,
     solver: Callable | None = None,
 ) -> OptimizeResult:
-    """Core sparse Newton implementation."""
-    if solver is None:
-        solver = sparse.linalg.spsolve
+    """Core sparse Newton implementation with backtracking line search.
 
-    res, jac = fun(x0, *args)
+    Uses the Armijo condition to globalize convergence. If the Newton direction is not a descent direction for the
+    merit function ``0.5 * ||F(x)||^2``, the direction is negated to guarantee descent. If the linear solve fails
+    (singular Jacobian), the solver falls back to a steepest-descent step on the merit function.
+    """
     x = x0.copy()
+    res, jac = fun(x, *args)
     nfev = 1
 
     err = np.max(np.abs(res))
-    if err < tol:
+    if err < f_tol:
         return OptimizeResult(x=x, success=True, message="Converged", fun=res, jac=jac, nit=0, nfev=nfev)
 
-    for iteration in range(1, 1 + maxiter):
-        dx = solver(jac, -res)
-        x = x + dx
+    phi_current = _phi(res)
+    phi_f_tol = 0.5 * f_tol * f_tol
 
-        res, jac = fun(x, *args)
-        nfev += 1
+    for iteration in range(1, maxiter + 1):
+        dx, _solve_ok = _solve_newton_step(jac, res, solver)
 
-        err = np.max(np.abs(res))
-        if err < tol:
+        slope = np.dot(res, jac @ dx)
+
+        if slope >= 0:
+            dx = -dx
+            slope = -slope
+
+        # Backtracking line search with Armijo condition
+        alpha = 1.0
+        accepted = False
+
+        for _ in range(max_ls):
+            x_trial = x + alpha * dx
+            res_trial, jac_trial = fun(x_trial, *args)
+            nfev += 1
+
+            phi_trial = _phi(res_trial)
+            if phi_trial <= phi_current + c1 * alpha * slope:
+                x, res, jac = x_trial, res_trial, jac_trial
+                phi_current = phi_trial
+                accepted = True
+                break
+
+            alpha *= beta
+
+        if not accepted:
             return OptimizeResult(
                 x=x,
-                success=True,
-                message="Converged",
+                success=False,
+                message=f"Line search failed after {max_ls} attempts (iteration {iteration})",
                 fun=res,
                 jac=jac,
                 nit=iteration,
                 nfev=nfev,
             )
 
+        # phi = 0.5 * ||res||^2 >= 0.5 * max(|res|)^2, so if phi > 0.5 * f_tol^2
+        # we know max(|res|) might still exceed f_tol but we need to check. When phi
+        # is orders of magnitude above this bound, skip the more expensive checks.
+        if phi_current <= phi_f_tol:
+            err = np.max(np.abs(res))
+            if err < f_tol:
+                return OptimizeResult(
+                    x=x,
+                    success=True,
+                    message="Converged",
+                    fun=res,
+                    jac=jac,
+                    nit=iteration,
+                    nfev=nfev,
+                )
+
+            if _check_convergence(alpha * dx, x, x_tol):
+                return OptimizeResult(
+                    x=x,
+                    success=True,
+                    message="Converged",
+                    fun=res,
+                    jac=jac,
+                    nit=iteration,
+                    nfev=nfev,
+                )
+
     return OptimizeResult(
         x=x,
         success=False,
-        message=f"Did not converge after {maxiter} iterations",
+        message=f"Did not converge after {maxiter} iterations (max |residual| = {np.max(np.abs(res)):.2e})",
         fun=res,
         jac=jac,
         nit=maxiter,
@@ -76,48 +158,79 @@ def sparse_newton(
     fun: Callable,
     x0: np.ndarray,
     args: tuple = (),
-    tol: float = 1e-10,
-    maxiter: int = 100,
+    tol: float | None = 1e-10,
+    x_tol: float | None = None,
+    f_tol: float | None = None,
+    beta: float = 0.5,
+    c1: float = 1e-4,
+    max_ls: int = 50,
+    maxiter: int = 1000,
     solver: Callable | None = None,
+    progressbar: bool = True,
 ) -> OptimizeResult:
     """Solve a nonlinear system using Newton's method with sparse Jacobian.
+
+    Finds ``x`` such that ``F(x) = 0`` where ``F`` returns both residuals and a sparse Jacobian. Convergence is
+    globalized via backtracking line search on the merit function ``0.5 * ||F(x)||^2`` with the Armijo condition.
+
+    The default linear solver is ``scipy.sparse.linalg.spsolve`` (sparse direct solve via LU). A custom ``solver``
+    callable can be provided for iterative methods (e.g., GMRES) on very large systems. If the linear solve fails
+    (singular Jacobian, non-finite result), the solver falls back to a steepest-descent step on the merit function.
 
     Parameters
     ----------
     fun : callable
-        Function that returns (residuals, jacobian) given x and *args.
-        Jacobian must be a scipy sparse matrix.
+        Function with signature ``fun(x, *args) -> (residuals, jacobian)``. The Jacobian must be a scipy sparse
+        matrix.
     x0 : ndarray
         Initial guess.
     args : tuple, optional
-        Extra arguments passed to fun.
+        Extra arguments passed to ``fun``.
     tol : float, default 1e-10
-        Convergence tolerance on the infinity norm of residuals.
-    maxiter : int, default 100
-        Maximum number of iterations.
+        Default convergence tolerance, used for both ``x_tol`` and ``f_tol`` when they are not provided.
+    x_tol : float, optional
+        Step-size convergence tolerance: the solver converges when
+        ``max(|dx|) < x_tol * (1 + max(|x|))``. Defaults to ``tol``.
+    f_tol : float, optional
+        Residual convergence tolerance: the solver converges when ``max(|F(x)|) < f_tol``. Defaults to ``tol``.
+    beta : float, default 0.5
+        Line search step reduction factor.
+    c1 : float, default 1e-4
+        Armijo sufficient decrease constant.
+    max_ls : int, default 50
+        Maximum number of line search reductions per iteration.
+    maxiter : int, default 1000
+        Maximum number of Newton iterations.
     solver : callable, optional
-        Sparse linear solver with signature solver(A, b) -> x.
-        Defaults to scipy.sparse.linalg.spsolve.
+        Sparse linear solver with signature ``solver(A, b) -> x``. When provided, this replaces the default
+        ``spsolve``. Useful for iterative solvers like GMRES on very large systems where direct factorization is
+        too expensive.
+    progressbar : bool, default True
+        Whether to display a progress bar during optimization.
 
     Returns
     -------
     OptimizeResult
-        Result object with solution and convergence info.
-
-    Raises
-    ------
-    ValueError
-        If fun does not return a (residuals, sparse_jacobian) tuple.
+        Result with fields ``x``, ``success``, ``message``, ``fun`` (final residuals), ``jac`` (final Jacobian),
+        ``nit`` (iterations), and ``nfev`` (function evaluations).
     """
     _validate_fused_fun(fun, x0, args)
 
-    # TODO: progressbar=False until better_optimize supports sparse jacobian display
+    if x_tol is None:
+        x_tol = tol
+    if f_tol is None:
+        f_tol = tol
+
+    # maxeval is set high enough that the iteration budget (not the eval budget) is the binding constraint.
+    # Each iteration may consume multiple evals during line search.
+    max_evals = maxiter * (max_ls + 1)
+
     objective = ObjectiveWrapper(
-        maxeval=maxiter,
+        maxeval=max_evals,
         f=fun,
         jac=None,
         args=args,
-        progressbar=False,
+        progressbar=progressbar,
         progressbar_update_interval=1,
         has_fused_f_and_grad=True,
         root=True,
@@ -127,7 +240,11 @@ def sparse_newton(
         _sparse_newton_core,
         fun=objective,
         x0=x0,
-        tol=tol,
+        x_tol=x_tol,
+        f_tol=f_tol,
+        beta=beta,
+        c1=c1,
+        max_ls=max_ls,
         maxiter=maxiter,
         solver=solver,
     )

--- a/gEconpy/solvers/sparse_newton.py
+++ b/gEconpy/solvers/sparse_newton.py
@@ -158,7 +158,7 @@ def sparse_newton(
     fun: Callable,
     x0: np.ndarray,
     args: tuple = (),
-    tol: float | None = 1e-10,
+    tol: float = 1e-10,
     x_tol: float | None = None,
     f_tol: float | None = None,
     beta: float = 0.5,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dependencies = [
     "setuptools",
     "sympy>=1.14.0",
     "sympytensor>=1.4.1",
+    "better-optimize>=0.2.1",
     "ipython",
     "xarray",
     "networkx"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,6 +161,7 @@ ignore = [
     "RUF002", # Allow Greek letters in docstrings
     "RUF012", # Mutable class attributes without ClassVar
     "PLR0913", # Allow functions with many arguments
+    "PLR2004", # Allow magic numbers
     "TRY003", # Allow custom exception messages
 
     # Allow missing docstrings; enforce style where present

--- a/tests/model/perfect_foresight/test_solve.py
+++ b/tests/model/perfect_foresight/test_solve.py
@@ -1,10 +1,14 @@
+from unittest.mock import patch
+
 import numpy as np
+import pandas as pd
 import pytest
 
 from numpy.testing import assert_allclose
 
 from gEconpy import impulse_response_function
 from gEconpy.model.perfect_foresight import solve_perfect_foresight
+from gEconpy.model.perfect_foresight.solve import _normalize_condition_keys, make_piecewise_x0
 from tests._resources.cache_compiled_models import load_and_cache_model
 
 
@@ -29,42 +33,8 @@ class TestSolve:
 
         assert result.success
         ss = rbc_model.steady_state(verbose=False)
-
         for var in trajectory.columns:
-            expected = ss[f"{var}_ss"]
-            assert_allclose(trajectory[var].values, expected, rtol=1e-6)
-
-    def test_converges_toward_terminal_from_perturbed_initial(self, rbc_model):
-        ss = rbc_model.steady_state(verbose=False)
-        K_ss = ss["K_ss"]
-
-        trajectory, result = solve_perfect_foresight(
-            rbc_model,
-            simulation_length=50,
-            initial_conditions={"K": 0.9 * K_ss},
-        )
-
-        assert result.success
-        # Should move toward steady state (closer at end than start)
-        initial_gap = abs(trajectory["K"].iloc[0] - K_ss)
-        final_gap = abs(trajectory["K"].iloc[-1] - K_ss)
-        assert final_gap < initial_gap
-
-    def test_shock_moves_trajectory_away_from_steady_state(self, rbc_model):
-        ss = rbc_model.steady_state(verbose=False)
-        simulation_length = 50
-        shock_path = np.zeros(simulation_length)
-        shock_path[0] = 0.01
-
-        trajectory, result = solve_perfect_foresight(
-            rbc_model,
-            simulation_length=simulation_length,
-            shocks={"epsilon": shock_path},
-        )
-
-        assert result.success
-        # First period should differ from steady state due to shock
-        assert not np.isclose(trajectory["K"].iloc[0], ss["K_ss"])
+            assert_allclose(trajectory[var].values, ss[f"{var}_ss"], rtol=1e-6)
 
 
 class TestBackwardOnlyModel:
@@ -73,12 +43,10 @@ class TestBackwardOnlyModel:
 
         assert result.success
         ss = backward_var_model.steady_state(verbose=False)
-
         for var in trajectory.columns:
-            expected = ss[f"{var}_ss"]
-            assert_allclose(trajectory[var].values, expected, atol=1e-10)
+            assert_allclose(trajectory[var].values, ss[f"{var}_ss"], atol=1e-10)
 
-    def test_converges_from_perturbed_initial(self, backward_var_model):
+    def test_matches_analytical_var1_solution(self, backward_var_model):
         simulation_length = 30
         y0 = np.array([1.0, 0.5])
 
@@ -89,23 +57,13 @@ class TestBackwardOnlyModel:
         )
         assert result.success
 
-        # VAR(1) coefficient matrix from model parameters
         params = backward_var_model.parameters()
-        A = np.array(
-            [
-                [params["rho_xx"], params["rho_xy"]],
-                [params["rho_yx"], params["rho_yy"]],
-            ]
-        )
-
-        # Analytical solution: y_t = A^t @ y_0
-        expected = np.zeros((simulation_length, 2))
-        for t in range(simulation_length):
-            expected[t] = np.linalg.matrix_power(A, t + 1) @ y0
+        A = np.array([[params["rho_xx"], params["rho_xy"]], [params["rho_yx"], params["rho_yy"]]])
+        expected = np.array([np.linalg.matrix_power(A, t + 1) @ y0 for t in range(simulation_length)])
 
         assert_allclose(trajectory[["x", "y"]].values, expected, rtol=1e-10)
 
-    def test_shock_response(self, backward_var_model):
+    def test_shock_response_matches_irf(self, backward_var_model):
         simulation_length = 30
         shock_path = np.zeros(simulation_length)
         shock_path[0] = 0.1
@@ -115,6 +73,7 @@ class TestBackwardOnlyModel:
             simulation_length=simulation_length,
             shocks={"epsilon_x": shock_path},
         )
+        assert result.success
 
         irf = (
             impulse_response_function(
@@ -125,10 +84,7 @@ class TestBackwardOnlyModel:
             .isel(shock=0)
             .to_pandas()
         )
-
-        # For a linear model, the IRF should match the perfect foresight response to a shock at t=0
-        assert result.success
-        np.testing.assert_allclose(trajectory["x"].values, irf["x"].values[1:])
+        assert_allclose(trajectory["x"].values, irf["x"].values[1:])
 
 
 class TestForwardOnlyModel:
@@ -137,38 +93,32 @@ class TestForwardOnlyModel:
 
         assert result.success
         ss = forward_model.steady_state(verbose=False)
-
         for var in trajectory.columns:
-            expected = ss[f"{var}_ss"]
-            assert_allclose(trajectory[var].values, expected, atol=1e-10)
+            assert_allclose(trajectory[var].values, ss[f"{var}_ss"], atol=1e-10)
 
     def test_natural_rate_shock_response(self, forward_model):
         simulation_length = 30
         shock_rn = np.zeros(simulation_length)
-        shock_rn[0] = 0.01  # 1% shock
+        shock_rn[0] = 0.01
 
         trajectory, result = solve_perfect_foresight(
             forward_model,
             simulation_length=simulation_length,
             shocks={"epsilon_rn": shock_rn},
         )
-
         assert result.success
 
-        # Natural rate shock is expansionary: raises x, pi, and i
+        # Expansionary shock raises all variables on impact
         assert trajectory["x"].iloc[0] > 0
         assert trajectory["pi"].iloc[0] > 0
         assert trajectory["i"].iloc[0] > 0
 
-        # rn follows AR(1), so rn[t] = shock * rho^t
-        params = forward_model.parameters()
-        rho = params["rho"]
-        expected_rn = 0.01 * (rho ** np.arange(simulation_length))
-        assert_allclose(trajectory["rn"].values, expected_rn, rtol=1e-10)
+        # rn follows AR(1) exactly
+        rho = forward_model.parameters()["rho"]
+        assert_allclose(trajectory["rn"].values, 0.01 * rho ** np.arange(simulation_length), rtol=1e-10)
 
-        # All variables should decay toward steady state
+        # All variables decay toward steady state
         assert abs(trajectory["x"].iloc[-1]) < abs(trajectory["x"].iloc[0])
-        assert abs(trajectory["pi"].iloc[-1]) < abs(trajectory["pi"].iloc[0])
 
     def test_taylor_rule_holds(self, forward_model):
         simulation_length = 20
@@ -180,15 +130,10 @@ class TestForwardOnlyModel:
             simulation_length=simulation_length,
             shocks={"epsilon_rn": shock_rn},
         )
-
         assert result.success
 
-        # Taylor rule: i = phi_pi * pi + phi_x * x
         params = forward_model.parameters()
-        phi_pi = params["phi_pi"]
-        phi_x = params["phi_x"]
-
-        expected_i = phi_pi * trajectory["pi"] + phi_x * trajectory["x"]
+        expected_i = params["phi_pi"] * trajectory["pi"] + params["phi_x"] * trajectory["x"]
         assert_allclose(trajectory["i"].values, expected_i.values, rtol=1e-10)
 
     def test_shock_response_matches_irf(self, forward_model):
@@ -201,6 +146,7 @@ class TestForwardOnlyModel:
             simulation_length=simulation_length,
             shocks={"epsilon_rn": shock_rn},
         )
+        assert result.success
 
         irf = (
             impulse_response_function(
@@ -211,8 +157,229 @@ class TestForwardOnlyModel:
             .isel(shock=0)
             .to_pandas()
         )
+        assert_allclose(
+            trajectory[["x", "pi", "i", "rn"]].values,
+            irf[["x", "pi", "i", "rn"]].iloc[1:].values,
+            atol=1e-8,
+            rtol=1e-8,
+        )
+
+
+class TestX0Dispatch:
+    def test_x0_dict_skips_steady_state_call(self, rbc_model):
+        ss_dict = rbc_model.steady_state(verbose=False)
+
+        with patch.object(type(rbc_model), "steady_state") as mock_ss:
+            _, result = solve_perfect_foresight(rbc_model, simulation_length=10, x0=dict(ss_dict))
 
         assert result.success
-        # IRF has shock at t=0 with response starting at t=1, so compare with offset
-        var_names = ["x", "pi", "i", "rn"]
-        assert_allclose(trajectory[var_names].values, irf[var_names].iloc[1:].values, atol=1e-8, rtol=1e-8)
+        mock_ss.assert_not_called()
+
+    def test_x0_array_with_full_conditions_skips_steady_state(self, rbc_model):
+        ss_dict = rbc_model.steady_state(verbose=False)
+        var_names = [v.base_name for v in rbc_model.variables]
+        simulation_length = 10
+
+        x0_mat = np.tile([ss_dict[f"{name}_ss"] for name in var_names], (simulation_length, 1))
+        full_conditions = {name: ss_dict[f"{name}_ss"] for name in var_names}
+
+        with patch.object(type(rbc_model), "steady_state") as mock_ss:
+            _, result = solve_perfect_foresight(
+                rbc_model,
+                simulation_length=simulation_length,
+                x0=x0_mat,
+                initial_conditions=full_conditions,
+                terminal_conditions=full_conditions,
+            )
+
+        assert result.success
+        mock_ss.assert_not_called()
+
+    def test_x0_dataframe_reindexes_columns(self, rbc_model):
+        ss_dict = rbc_model.steady_state(verbose=False)
+        var_names = [v.base_name for v in rbc_model.variables]
+        simulation_length = 10
+
+        # Build a DataFrame with columns in reversed order
+        reversed_names = list(reversed(var_names))
+        x0_df = pd.DataFrame(
+            np.tile([ss_dict[f"{name}_ss"] for name in reversed_names], (simulation_length, 1)),
+            columns=reversed_names,
+        )
+
+        _, result = solve_perfect_foresight(rbc_model, simulation_length=simulation_length, x0=x0_df)
+        assert result.success
+
+    @pytest.mark.parametrize("bad_shape", [(5, 3), (10,), (20, 1)])
+    def test_x0_array_wrong_shape_raises(self, rbc_model, bad_shape):
+        with pytest.raises(ValueError, match="x0 array must have shape"):
+            solve_perfect_foresight(rbc_model, simulation_length=20, x0=np.zeros(bad_shape))
+
+    def test_x0_dataframe_wrong_length_raises(self, rbc_model):
+        with pytest.raises(ValueError, match="rows"):
+            solve_perfect_foresight(rbc_model, simulation_length=20, x0=pd.DataFrame(np.zeros((5, 1))))
+
+
+class TestSteadyStateKwargs:
+    def test_setdefault_verbose_false_and_forwarding(self, rbc_model):
+        with patch.object(type(rbc_model), "steady_state", wraps=rbc_model.steady_state) as mock_ss:
+            solve_perfect_foresight(rbc_model, simulation_length=10, steady_state_kwargs={"progressbar": False})
+            kwargs = mock_ss.call_args[1]
+            assert kwargs["verbose"] is False
+            assert kwargs["progressbar"] is False
+
+    def test_explicit_verbose_not_overridden(self, rbc_model):
+        with patch.object(type(rbc_model), "steady_state", wraps=rbc_model.steady_state) as mock_ss:
+            solve_perfect_foresight(rbc_model, simulation_length=10, steady_state_kwargs={"verbose": True})
+            assert mock_ss.call_args[1]["verbose"] is True
+
+
+class TestConditionKeyNormalization:
+    @pytest.mark.parametrize(
+        "input_dict, expected",
+        [
+            ({"K_ss": 1.0, "C_ss": 2.0}, {"K": 1.0, "C": 2.0}),
+            ({"K": 1.0, "C": 2.0}, {"K": 1.0, "C": 2.0}),
+            ({"K_ss": 1.0, "C": 2.0}, {"K": 1.0, "C": 2.0}),
+        ],
+    )
+    def test_normalize_strips_ss_suffix(self, input_dict, expected):
+        assert _normalize_condition_keys(input_dict) == expected
+
+    def test_ss_dict_as_conditions_matches_default(self, rbc_model):
+        ss_dict = rbc_model.steady_state(verbose=False)
+
+        traj_default, _ = solve_perfect_foresight(
+            rbc_model,
+            simulation_length=50,
+            initial_conditions={"K": 0.9 * ss_dict["K_ss"]},
+        )
+        traj_explicit, _ = solve_perfect_foresight(
+            rbc_model,
+            simulation_length=50,
+            initial_conditions={"K_ss": 0.9 * ss_dict["K_ss"]},
+            terminal_conditions=dict(ss_dict),
+        )
+
+        assert_allclose(traj_default.values, traj_explicit.values, rtol=1e-10)
+
+
+class TestMakePiecewiseX0:
+    INIT_SS = {"K_ss": 1.0, "C_ss": 0.5, "Y_ss": 0.8}
+    TERM_SS = {"K_ss": 2.0, "C_ss": 1.0, "Y_ss": 1.6}
+
+    def test_returns_dataframe_with_correct_structure(self):
+        x0 = make_piecewise_x0(self.INIT_SS, self.TERM_SS, simulation_length=100)
+
+        assert isinstance(x0, pd.DataFrame)
+        assert len(x0) == 100
+        assert sorted(x0.columns) == ["C", "K", "Y"]
+
+    def test_step_transition_at_midpoint(self):
+        x0 = make_piecewise_x0(self.INIT_SS, self.TERM_SS, simulation_length=100)
+
+        # Default: step at simulation_length // 2
+        assert_allclose(x0.loc[49, "K"], 1.0)
+        assert_allclose(x0.loc[50, "K"], 2.0)
+
+    def test_smooth_transition_interpolates_linearly(self):
+        x0 = make_piecewise_x0(
+            self.INIT_SS,
+            self.TERM_SS,
+            simulation_length=100,
+            transition_start=40,
+            transition_periods=21,
+        )
+
+        # Before and after transition region
+        assert_allclose(x0.loc[39, "K"], 1.0)
+        assert_allclose(x0.loc[61, "K"], 2.0)
+
+        # Endpoints of the transition region (weight=0 and weight=1)
+        assert_allclose(x0.loc[40, "K"], 1.0)
+        assert_allclose(x0.loc[60, "K"], 2.0)
+
+        # Exact midpoint (index 10 of 21, weight = 10/20 = 0.5)
+        assert_allclose(x0.loc[50, "K"], 1.5)
+        assert_allclose(x0.loc[50, "C"], 0.75)
+
+    def test_infers_var_names_and_accepts_unsuffixed_keys(self):
+        x0_suffixed = make_piecewise_x0(self.INIT_SS, self.TERM_SS, simulation_length=10)
+        x0_bare = make_piecewise_x0(
+            {"K": 1.0, "C": 0.5, "Y": 0.8}, {"K": 2.0, "C": 1.0, "Y": 1.6}, simulation_length=10
+        )
+
+        assert_allclose(x0_suffixed.values, x0_bare.values)
+        assert list(x0_suffixed.columns) == list(x0_bare.columns)
+
+    def test_explicit_var_names_controls_column_order(self):
+        var_names = ["Y", "K", "C"]
+        x0 = make_piecewise_x0(self.INIT_SS, self.TERM_SS, simulation_length=10, var_names=var_names)
+
+        assert list(x0.columns) == var_names
+        assert_allclose(x0.iloc[0].values, [0.8, 1.0, 0.5])
+
+
+class TestParamPaths:
+    def test_scalar_path_changes_steady_state(self, rbc_model):
+        ss_default = rbc_model.steady_state(verbose=False)
+        traj_default, res_default = solve_perfect_foresight(rbc_model, simulation_length=20)
+
+        # A different depreciation rate should yield a different fixed point
+        params = rbc_model.parameters()
+        delta = params["delta"]
+        traj_override, res_override = solve_perfect_foresight(
+            rbc_model,
+            simulation_length=20,
+            param_paths={"delta": delta * 1.5},
+        )
+
+        assert res_default.success and res_override.success
+        assert not np.allclose(traj_default["K"].values, traj_override["K"].values)
+
+    def test_none_param_paths_matches_default(self, rbc_model):
+        traj_default, _ = solve_perfect_foresight(rbc_model, simulation_length=20)
+        traj_explicit, _ = solve_perfect_foresight(rbc_model, simulation_length=20, param_paths=None)
+
+        assert_allclose(traj_default.values, traj_explicit.values)
+
+    def test_time_varying_path_accepted(self, rbc_model):
+        params = rbc_model.parameters()
+        T = 20
+        delta_path = np.full(T, params["delta"])
+        delta_path[T // 2 :] *= 1.5
+
+        _, result = solve_perfect_foresight(rbc_model, simulation_length=T, param_paths={"delta": delta_path})
+        assert result.success
+
+    def test_boundary_ss_uses_param_paths(self, rbc_model):
+        params = rbc_model.parameters()
+        T = 50
+        delta_init = params["delta"]
+        delta_term = delta_init * 1.5
+        delta_path = np.where(np.arange(T) < T // 2, delta_init, delta_term)
+
+        ss_init = rbc_model.steady_state(verbose=False, delta=delta_init)
+        ss_term = rbc_model.steady_state(verbose=False, delta=delta_term)
+
+        # Without explicit conditions, solver should auto-compute distinct boundary SS values
+        x0 = make_piecewise_x0(ss_init, ss_term, simulation_length=T, transition_periods=10)
+        traj_auto, res_auto = solve_perfect_foresight(
+            rbc_model,
+            simulation_length=T,
+            x0=x0,
+            param_paths={"delta": delta_path},
+        )
+
+        # With explicit conditions matching the same SS values
+        traj_explicit, res_explicit = solve_perfect_foresight(
+            rbc_model,
+            simulation_length=T,
+            x0=x0,
+            initial_conditions=ss_init,
+            terminal_conditions=ss_term,
+            param_paths={"delta": delta_path},
+        )
+
+        assert res_auto.success and res_explicit.success
+        assert_allclose(traj_auto.values, traj_explicit.values, rtol=1e-8)

--- a/tests/model/perfect_foresight/test_solve.py
+++ b/tests/model/perfect_foresight/test_solve.py
@@ -195,12 +195,27 @@ class TestX0Dispatch:
         assert result.success
         mock_ss.assert_not_called()
 
+    @pytest.mark.parametrize("x0_type", ["ndarray", "dataframe"])
+    def test_x0_with_full_initial_but_no_terminal_computes_terminal_ss(self, rbc_model, x0_type):
+        ss_dict = rbc_model.steady_state(verbose=False)
+        var_names = [v.base_name for v in rbc_model.variables]
+        simulation_length = 10
+
+        x0_mat = np.tile([ss_dict[f"{name}_ss"] for name in var_names], (simulation_length, 1))
+        full_initial = {name: ss_dict[f"{name}_ss"] for name in var_names}
+
+        x0 = pd.DataFrame(x0_mat, columns=var_names) if x0_type == "dataframe" else x0_mat
+
+        _, result = solve_perfect_foresight(
+            rbc_model, simulation_length=simulation_length, x0=x0, initial_conditions=full_initial
+        )
+        assert result.success
+
     def test_x0_dataframe_reindexes_columns(self, rbc_model):
         ss_dict = rbc_model.steady_state(verbose=False)
         var_names = [v.base_name for v in rbc_model.variables]
         simulation_length = 10
 
-        # Build a DataFrame with columns in reversed order
         reversed_names = list(reversed(var_names))
         x0_df = pd.DataFrame(
             np.tile([ss_dict[f"{name}_ss"] for name in reversed_names], (simulation_length, 1)),

--- a/tests/model/perfect_foresight/test_validation.py
+++ b/tests/model/perfect_foresight/test_validation.py
@@ -3,6 +3,8 @@ import pytest
 
 from gEconpy.model.perfect_foresight.validation import validate_perfect_foresight_inputs
 
+COMMON_KWARGS = {"var_names": ["K", "C"], "shock_names": ["epsilon"], "param_names": ["alpha", "beta"]}
+
 
 class TestValidation:
     def test_invalid_initial_condition_raises(self):
@@ -11,9 +13,9 @@ class TestValidation:
                 initial_conditions={"not_a_var": 1.0},
                 terminal_conditions={},
                 shocks=None,
-                var_names=["K", "C"],
-                shock_names=["epsilon"],
+                param_paths=None,
                 simulation_length=10,
+                **COMMON_KWARGS,
             )
 
     def test_invalid_shock_raises(self):
@@ -22,9 +24,9 @@ class TestValidation:
                 initial_conditions={},
                 terminal_conditions={},
                 shocks={"not_a_shock": np.ones(10)},
-                var_names=["K", "C"],
-                shock_names=["epsilon"],
+                param_paths=None,
                 simulation_length=10,
+                **COMMON_KWARGS,
             )
 
     def test_wrong_shock_length_raises(self):
@@ -33,7 +35,39 @@ class TestValidation:
                 initial_conditions={},
                 terminal_conditions={},
                 shocks={"epsilon": np.ones(5)},
-                var_names=["K", "C"],
-                shock_names=["epsilon"],
+                param_paths=None,
                 simulation_length=10,
+                **COMMON_KWARGS,
             )
+
+    def test_invalid_param_path_raises(self):
+        with pytest.raises(ValueError, match="Unknown parameters in param_paths"):
+            validate_perfect_foresight_inputs(
+                initial_conditions={},
+                terminal_conditions={},
+                shocks=None,
+                param_paths={"not_a_param": 1.0},
+                simulation_length=10,
+                **COMMON_KWARGS,
+            )
+
+    def test_wrong_param_path_length_raises(self):
+        with pytest.raises(ValueError, match="param_paths\\['alpha'\\] has length 5, expected 10"):
+            validate_perfect_foresight_inputs(
+                initial_conditions={},
+                terminal_conditions={},
+                shocks=None,
+                param_paths={"alpha": np.ones(5)},
+                simulation_length=10,
+                **COMMON_KWARGS,
+            )
+
+    def test_scalar_param_path_accepted(self):
+        validate_perfect_foresight_inputs(
+            initial_conditions={},
+            terminal_conditions={},
+            shocks=None,
+            param_paths={"alpha": 0.5},
+            simulation_length=10,
+            **COMMON_KWARGS,
+        )

--- a/tests/solvers/test_sparse_newton.py
+++ b/tests/solvers/test_sparse_newton.py
@@ -77,8 +77,8 @@ def make_singular_system():
     """System with a singular Jacobian at x0 to test fallback behavior."""
 
     def fun(x):
-        res = np.array([x[0] ** 3, x[1] ** 3])
-        jac = sparse.diags(3 * x**2, format="csc")
+        res = np.array([x[0] + x[1] - 3.0, x[0] * x[1] - 2.0])
+        jac = sparse.csc_matrix(np.array([[1.0, 1.0], [x[1], x[0]]]))
         return res, jac
 
     return fun
@@ -153,13 +153,14 @@ class TestSparseNewtonConvergence:
         np.testing.assert_allclose(result.fun, 0.0, atol=1e-10)
 
     def test_singular_jacobian_at_start(self):
-        """The solver should not crash when the initial Jacobian is singular."""
-        result = sparse_newton(make_singular_system(), np.array([0.0, 0.0]), tol=1e-8, maxiter=200)
+        """The solver should fall back to steepest descent when the initial Jacobian is singular."""
+        x0 = np.array([1.0, 1.0])
+        initial_residual = np.linalg.norm(make_singular_system()(x0)[0])
 
-        # The root is at [0, 0] which is exactly x0, but the Jacobian is zero there
-        # so the solver can't verify convergence via the Newton step. It should still
-        # return without crashing.
-        assert isinstance(result.fun, np.ndarray)
+        result = sparse_newton(make_singular_system(), x0, tol=1e-8, maxiter=500)
+
+        assert result.nit > 0, "Solver should attempt iterations (x0 is not the root)"
+        assert np.linalg.norm(result.fun) < initial_residual, "Residual should improve from initial point"
 
 
 class TestSparseNewtonOptions:
@@ -195,3 +196,4 @@ class TestSparseNewtonOptions:
 
         assert result.success
         np.testing.assert_allclose(result.x, [1.0, 2.0], rtol=1e-8)
+        assert nfev_counter["n"] > result.nit + 1, "Line search should backtrack at least once from x0=[100,100]"

--- a/tests/solvers/test_sparse_newton.py
+++ b/tests/solvers/test_sparse_newton.py
@@ -2,7 +2,6 @@ import numpy as np
 import pytest
 
 from scipy import sparse
-from scipy.optimize import OptimizeResult
 from scipy.sparse.linalg import gmres
 
 from gEconpy.solvers.sparse_newton import sparse_newton
@@ -40,12 +39,7 @@ def make_trig_system(a=1.0, b=1.0):
     """
 
     def fun(x):
-        res = np.array(
-            [
-                a * x[0] * np.cos(x[1]) - 4,
-                x[1] * x[0] - b * x[1] - 5,
-            ]
-        )
+        res = np.array([a * x[0] * np.cos(x[1]) - 4, x[1] * x[0] - b * x[1] - 5])
         jac = sparse.csc_matrix(
             [
                 [a * np.cos(x[1]), -a * x[0] * np.sin(x[1])],
@@ -57,34 +51,55 @@ def make_trig_system(a=1.0, b=1.0):
     return fun
 
 
+def make_broyden_tridiagonal(n=100):
+    """Broyden tridiagonal system -- a classic large sparse test problem.
+
+    f_i = (3 - 2*x_i)*x_i - x_{i-1} - 2*x_{i+1} + 1, with x_0 = x_{n+1} = 0.
+    """
+
+    def fun(x):
+        res = (3.0 - 2.0 * x) * x + 1.0
+        res[:-1] -= 2.0 * x[1:]
+        res[1:] -= x[:-1]
+
+        diag = 3.0 - 4.0 * x
+        jac = sparse.diags(
+            [-np.ones(n - 1), diag, -2.0 * np.ones(n - 1)],
+            [-1, 0, 1],
+            format="csc",
+        )
+        return res, jac
+
+    return fun
+
+
+def make_singular_system():
+    """System with a singular Jacobian at x0 to test fallback behavior."""
+
+    def fun(x):
+        res = np.array([x[0] ** 3, x[1] ** 3])
+        jac = sparse.diags(3 * x**2, format="csc")
+        return res, jac
+
+    return fun
+
+
 class TestSparseNewtonValidation:
     def test_rejects_non_tuple_return(self):
-        def bad_fun(x):
-            return x
-
         with pytest.raises(ValueError, match="must return a tuple"):
-            sparse_newton(bad_fun, np.array([1.0]))
+            sparse_newton(lambda x: x, np.array([1.0]))
 
     def test_rejects_wrong_tuple_length(self):
-        def bad_fun(x):
-            return (x, x, x)
-
         with pytest.raises(ValueError, match="must return a tuple"):
-            sparse_newton(bad_fun, np.array([1.0]))
+            sparse_newton(lambda x: (x, x, x), np.array([1.0]))
 
     def test_rejects_non_array_residuals(self):
-        def bad_fun(_x):
-            return [1.0, 2.0], sparse.eye(2)
-
         with pytest.raises(TypeError, match="residuals as ndarray"):
-            sparse_newton(bad_fun, np.array([1.0, 2.0]))
+            sparse_newton(lambda _x: ([1.0, 2.0], sparse.eye(2)), np.array([1.0, 2.0]))
 
     def test_rejects_dense_jacobian(self):
-        def bad_fun(_x):
-            return np.array([1.0]), np.array([[1.0]])
-
         with pytest.raises(TypeError, match="sparse jacobian"):
-            sparse_newton(bad_fun, np.array([1.0]))
+            sparse_newton(lambda _x: (np.array([1.0]), np.array([[1.0]])), np.array([1.0]))
 
 
 class TestSparseNewtonConvergence:
@@ -125,6 +140,27 @@ class TestSparseNewtonConvergence:
         assert result.nit == 2
         assert "Did not converge" in result.message
 
+    def test_broyden_tridiagonal_small(self):
+        result = sparse_newton(make_broyden_tridiagonal(50), -np.ones(50), tol=1e-10)
+
+        assert result.success
+        np.testing.assert_allclose(result.fun, 0.0, atol=1e-10)
+
+    def test_broyden_tridiagonal_large(self):
+        result = sparse_newton(make_broyden_tridiagonal(1000), -np.ones(1000), tol=1e-10)
+
+        assert result.success
+        np.testing.assert_allclose(result.fun, 0.0, atol=1e-10)
+
+    def test_singular_jacobian_at_start(self):
+        """The solver should not crash when the initial Jacobian is singular."""
+        result = sparse_newton(make_singular_system(), np.array([0.0, 0.0]), tol=1e-8, maxiter=200)
+
+        # The root is at [0, 0] which is exactly x0, but the Jacobian is zero there
+        # so the solver can't verify convergence via the Newton step. It should still
+        # return without crashing.
+        assert isinstance(result.fun, np.ndarray)
+
 
 class TestSparseNewtonOptions:
     def test_gmres_solver(self):
@@ -138,13 +174,24 @@ class TestSparseNewtonOptions:
         np.testing.assert_allclose(result.x, [6.50409711, 0.90841421], rtol=1e-6)
 
     def test_args_passed_to_fun(self):
-        result = sparse_newton(
-            make_trig_system(a=2.0, b=0.5),
-            np.array([1.0, 1.0]),
-        )
+        result = sparse_newton(make_trig_system(a=2.0, b=0.5), np.array([1.0, 1.0]))
 
         assert result.success
-        # Verify solution satisfies the system
         x = result.x
         np.testing.assert_allclose(2.0 * x[0] * np.cos(x[1]) - 4, 0, atol=1e-8)
         np.testing.assert_allclose(x[1] * x[0] - 0.5 * x[1] - 5, 0, atol=1e-8)
+
+    def test_line_search_does_not_double_step(self):
+        """Regression test: the line search must not take a full step before backtracking."""
+        nfev_counter = {"n": 0}
+
+        def tracking_fun(x):
+            nfev_counter["n"] += 1
+            res = x**2 - np.array([1.0, 4.0])
+            jac = sparse.diags(2 * x, format="csc")
+            return res, jac
+
+        result = sparse_newton(tracking_fun, np.array([100.0, 100.0]), tol=1e-10, maxiter=200)
+
+        assert result.success
+        np.testing.assert_allclose(result.x, [1.0, 2.0], rtol=1e-8)


### PR DESCRIPTION
- Add line search to sparse_newton
- Pre-allocate memory when building perfect foresight problem
- Add support for permanent shocks (param_path)
- Accept output of model.steady_state for initial/terminal conditions
- Allow user to pass x0
- Add helper function to build an x0 that interpolates between initial and terminal conditions
- Automatically solve for initial and terminal conditions using params_path

<!-- readthedocs-preview gEconpy start -->
----
📚 Documentation preview 📚: https://gEconpy--72.org.readthedocs.build/en/72/

<!-- readthedocs-preview gEconpy end -->