### PR TITLE
Allow steady state in parameters when closed-form is known

### DIFF
--- a/gEconpy/model/block.py
+++ b/gEconpy/model/block.py
@@ -90,6 +90,7 @@ class Block:
         equation_flags: dict[int, dict[str, bool]] | None = None,
         source: str | None = None,
         symbol_locations: dict[str, ParseLocation] | None = None,
+        ss_solution_dict=None,
     ) -> None:
         """
         Initialize a Block from sympy equations.
@@ -121,6 +122,10 @@ class Block:
         symbol_locations : dict, optional
             Dictionary mapping symbol names to their ParseLocation in the source.
             Used for rich error reporting during validation.
+        ss_solution_dict : SymbolDictionary, optional
+            Analytically known steady-state solutions. Used to resolve calibration
+            expressions that reference steady-state variables (e.g.
+            ``phi_B = f(Y[ss])``).
         """
         self.name = name
         self.short_name = "".join(word[0] for word in name.split("_"))
@@ -146,6 +151,7 @@ class Block:
         # Store source info for rich error reporting
         self._source = source
         self._symbol_locations = symbol_locations or {}
+        self._ss_solution_dict = ss_solution_dict
 
         # Count equations
         self.n_equations = sum(
@@ -410,11 +416,17 @@ class Block:
                 # functions of other parameters that the user wants to keep track of.
 
                 # Check that these are functions of numbers and parameters only
-                if any(isinstance(x, TimeAwareSymbol) for x in atoms):
-                    raise ValueError(
-                        "Parameters defined as functions in the calibration sub-block cannot be functions "
-                        f"of variables. Found:\n\n {eq} in {self.name}"
-                    )
+                ss_vars = [x for x in atoms if isinstance(x, TimeAwareSymbol)]
+                if ss_vars:
+                    # Allow steady-state variable references if we have analytic solutions
+                    rhs = self._try_substitute_ss_values(eq, rhs, ss_vars)
+                    # Re-check: if variables remain after substitution, it's an error
+                    if any(isinstance(x, TimeAwareSymbol) for x in rhs.atoms()):
+                        raise ValueError(
+                            "Parameters defined as functions in the calibration sub-block cannot be functions "
+                            f"of variables. Found:\n\n {eq} in {self.name}"
+                        )
+
                 if eq.lhs in self.deterministic_dict:
                     duplicates.append(lhs)
                 else:
@@ -425,6 +437,66 @@ class Block:
             first_dup = duplicates[0]
             location = self._symbol_locations.get(str(first_dup))
             raise DuplicateParameterError(duplicates, self.name, source=self._source, location=location)
+
+    def _try_substitute_ss_values(
+        self,
+        eq: sp.Eq,
+        rhs: sp.Expr,
+        ss_vars: list[TimeAwareSymbol],
+    ) -> sp.Expr:
+        """Substitute analytic steady-state values into a calibration RHS.
+
+        If all steady-state variables in ``rhs`` have analytic solutions in the
+        model's STEADY_STATE block, substitute them away so the expression
+        becomes a pure function of parameters.
+
+        Parameters
+        ----------
+        eq : sp.Eq
+            The original calibration equation (for error messages).
+        rhs : sp.Expr
+            Right-hand side expression to substitute into.
+        ss_vars : list of TimeAwareSymbol
+            Steady-state variables found in ``rhs``.
+
+        Returns
+        -------
+        sp.Expr
+            The substituted expression.
+        """
+        if not all(x.time_index == "ss" for x in ss_vars):
+            raise ValueError(
+                "Parameters defined as functions in the calibration sub-block cannot be functions "
+                f"of variables. Found:\n\n {eq} in {self.name}"
+            )
+
+        if not self._ss_solution_dict:
+            raise ValueError(
+                f"Calibration expression {eq} in {self.name} references steady-state variables "
+                f"but no STEADY_STATE block with analytic solutions was found."
+            )
+
+        ss_sympy = self._ss_solution_dict.to_sympy()
+        sub_dict = {}
+        missing = []
+        for var in ss_vars:
+            matched = False
+            for key, value in ss_sympy.items():
+                if hasattr(key, "name") and key.name == var.name:
+                    sub_dict[var] = value
+                    matched = True
+                    break
+            if not matched:
+                missing.append(var)
+
+        if missing:
+            names = ", ".join(str(v) for v in missing)
+            raise ValueError(
+                f"Calibration expression {eq} in {self.name} references steady-state variables "
+                f"without analytic solutions: {names}. Provide analytic values in the STEADY_STATE block."
+            )
+
+        return rhs.subs(sub_dict)
 
     def _build_lagrangian(self) -> sp.Add:
         """Build the Lagrangian associated with the block's optimization program."""

--- a/gEconpy/parser/loader.py
+++ b/gEconpy/parser/loader.py
@@ -394,8 +394,18 @@ def ast_model_to_primitives(
     assumptions = dict(model.assumptions) if model.assumptions else {}
     options = model.options
 
+    # Extract steady state solutions first — blocks need them to resolve
+    # calibration expressions that reference steady-state variables
+    ss_solution_dict = _extract_ss_solution_dict(model, assumptions)
+
     # Build Block objects and solve optimization
-    block_dict = ast_model_to_block_dict(model, assumptions=assumptions, simplify_blocks=simplify_blocks, source=source)
+    block_dict = ast_model_to_block_dict(
+        model,
+        assumptions=assumptions,
+        simplify_blocks=simplify_blocks,
+        source=source,
+        ss_solution_dict=ss_solution_dict,
+    )
 
     # Extract primitives from blocks
     equations = _block_dict_to_equation_list(block_dict)
@@ -406,9 +416,6 @@ def ast_model_to_primitives(
 
     # Convert tryreduce strings to symbols
     tryreduce = _extract_tryreduce(model, variables)
-
-    # Extract steady state solutions from STEADY_STATE block
-    ss_solution_dict = _extract_ss_solution_dict(model, assumptions)
 
     # Handle distributions from calibration and shock blocks
     distributions = SymbolDictionary()

--- a/gEconpy/parser/transform/to_block.py
+++ b/gEconpy/parser/transform/to_block.py
@@ -101,6 +101,7 @@ def ast_block_to_block(
     ast_block: GCNBlock,
     assumptions: dict[str, dict[str, bool]] | None = None,
     source: str | None = None,
+    ss_solution_dict=None,
 ) -> Block:
     """
     Convert a GCNBlock AST directly to a Block objec.
@@ -113,6 +114,9 @@ def ast_block_to_block(
         Variable assumptions for sympy symbols.
     source : str, optional
         The source code of the GCN file, for rich error reporting.
+    ss_solution_dict : SymbolDictionary, optional
+        Analytically known steady-state solutions. Forwarded to Block for
+        resolving calibration expressions that reference steady-state variables.
 
     Returns
     -------
@@ -184,6 +188,7 @@ def ast_block_to_block(
         equation_flags=equation_flags,
         source=source,
         symbol_locations=symbol_locations,
+        ss_solution_dict=ss_solution_dict,
     )
 
 
@@ -250,6 +255,7 @@ def ast_model_to_block_dict(
     assumptions: dict[str, dict[str, bool]] | None = None,
     simplify_blocks: bool = False,
     source: str | None = None,
+    ss_solution_dict=None,
 ) -> dict[str, Block]:
     """
     Convert a GCNModel AST to a dictionary of Block objects.
@@ -267,6 +273,9 @@ def ast_model_to_block_dict(
         Whether to simplify block equations during optimization.
     source : str, optional
         The source code of the GCN file, for rich error reporting.
+    ss_solution_dict : SymbolDictionary, optional
+        Analytically known steady-state solutions. Used to resolve calibration
+        expressions that reference steady-state variables.
 
     Returns
     -------
@@ -286,7 +295,7 @@ def ast_model_to_block_dict(
 
         expanded_block = expand_block_time_indices(ast_block)
 
-        block = ast_block_to_block(expanded_block, assumptions, source=source)
+        block = ast_block_to_block(expanded_block, assumptions, source=source, ss_solution_dict=ss_solution_dict)
 
         block.solve_optimization(try_simplify=simplify_blocks)
         block_dict[block.name] = block

--- a/tests/model/test_block.py
+++ b/tests/model/test_block.py
@@ -660,3 +660,39 @@ def test_lagged_definition_produces_derivative_in_foc():
     bond_foc = block.system_equations[-1]
     bond_foc = bond_foc.collect(R_star).collect(Phi_B)
     assert bond_foc == expected_bond_foc
+
+
+def test_ss_variable_in_calibration_resolves_to_deterministic_param():
+    gcn = """
+    block STEADY_STATE
+    {
+        identities
+        {
+            Y[ss] = Y_bar;
+        };
+    };
+
+    block HOUSEHOLD
+    {
+        identities
+        {
+            Y[] = A[] * L[];
+        };
+
+        calibration
+        {
+            alpha = 0.5;
+            phi = Y[ss] ^ 2 + alpha;
+            Y_bar = 0.8;
+        };
+    };
+    """
+    result = load_gcn_string(gcn)
+    block = result.block_dict["HOUSEHOLD"]
+
+    alpha = sp.Symbol("alpha")
+    Y_bar = sp.Symbol("Y_bar")
+    phi = sp.Symbol("phi")
+
+    assert phi in block.deterministic_dict
+    assert block.deterministic_dict[phi] == Y_bar**2 + alpha


### PR DESCRIPTION
There are times when it's nice to define model parameters in terms of steady state variables. You're not allowed to define a parameter in terms of variables (because then it's a variable), but the steady state is itself a parameter in a sense.

Specifically, when an analytic steady state is available, we can just replace steady state symbols in parameters with an equation. This PR allows that.  

<!-- readthedocs-preview gEconpy start -->
----
📚 Documentation preview 📚: https://gEconpy--80.org.readthedocs.build/en/80/

<!-- readthedocs-preview gEconpy end -->