### PR TITLE
Improve error messages

### DIFF
--- a/gEconpy/__init__.py
+++ b/gEconpy/__init__.py
@@ -49,7 +49,6 @@ __all__ = [
     "classes",
     "data",
     "data_from_prior",
-    "exceptions",
     "impulse_response_function",
     "make_mod_file",
     "matrix_to_dataframe",

--- a/gEconpy/exceptions.py
+++ b/gEconpy/exceptions.py
@@ -106,8 +106,11 @@ class GCNValidationError(ValueError):
 
         for i in range(start, end):
             line_num = i + 1
-            line_content = lines[i]
-            parts.append(f"  {line_num:>{width}} | {line_content}")
+            line_content = lines[i].rstrip()
+            if line_content:
+                parts.append(f"  {line_num:>{width}} | {line_content}")
+            else:
+                parts.append(f"  {line_num:>{width}} |")
 
             # Add caret and annotation under the error line
             if line_num == line and self.location.column is not None:

--- a/gEconpy/model/build.py
+++ b/gEconpy/model/build.py
@@ -44,7 +44,7 @@ def _print_parse_error(error: GCNParseError | GCNErrorCollection, gcn_path: Path
     if isinstance(error, GCNErrorCollection):
         print(formatter.format_error_collection(error), file=sys.stderr)
     else:
-        source = gcn_path.read_text() if gcn_path.exists() else None
+        source = gcn_path.read_text(encoding="utf-8") if gcn_path.exists() else None
         print(formatter.format_error(error, source), file=sys.stderr)
 
 

--- a/gEconpy/parser/grammar/components.py
+++ b/gEconpy/parser/grammar/components.py
@@ -8,6 +8,7 @@ from gEconpy.parser.grammar.statements import (
     DIST_EXPR,
     DISTRIBUTION,
     EQUATION,
+    MISSING_TILDE,
     VARIABLE_LIST,
     VARIABLE_REF,
 )
@@ -112,7 +113,7 @@ SHOCKS = (KW_SHOCKS.suppress() - LBRACE - pp.ZeroOrMore(SHOCK_ITEM)("shock_items
     _build_shocks
 )
 
-CALIBRATION_ITEM = DISTRIBUTION | EQUATION
+CALIBRATION_ITEM = DISTRIBUTION | MISSING_TILDE | EQUATION
 
 
 def _build_calibration(tokens) -> tuple[str, list[GCNEquation | GCNDistribution]]:

--- a/gEconpy/parser/grammar/statements.py
+++ b/gEconpy/parser/grammar/statements.py
@@ -167,21 +167,29 @@ MISSING_EQUALS = (
 ).set_parse_action(_missing_equals_fail)
 
 
-def _check_after_expr(s: str, loc: int, toks):
-    while loc < len(s) and s[loc] in " \t\n":
-        loc += 1
-    if loc < len(s):
-        next_char = s[loc]
-        if next_char in ")]}":
-            raise pp.ParseException(s, loc, f"Unmatched '{next_char}'")
-    return toks
+def _unmatched_close_fail(s: str, loc: int, toks) -> None:
+    char = toks[0]
+    raise GCNParseFailure(
+        s,
+        loc,
+        f"Unmatched '{char}' — extra closing bracket with no matching opener",
+        code=ErrorCode.E007,
+        found=char,
+    )
 
+
+_UNMATCHED_CLOSE = pp.Regex(r"[)\]}]").copy().set_parse_action(_unmatched_close_fail)
+
+# After the RHS expression, check for stray closing brackets before the semicolon.
+# The FollowedBy(Regex) peeks ahead; if we see a closing bracket, match and fail fatally.
+_POST_RHS_CHECK = pp.Optional(_UNMATCHED_CLOSE)
 
 _VALID_EQUATION = (
     pp.ZeroOrMore(TAG)("tags")
     + EXPR("lhs")
     + pp.Suppress(pp.Literal("="))
-    + EXPR("rhs").add_parse_action(_check_after_expr)
+    + EXPR("rhs")
+    + _POST_RHS_CHECK
     + pp.Optional(LAGRANGE_MULT)("lagrange")
     + pp.Optional(CALIBRATING_PARAM)("calibrating")
     + SEMI
@@ -393,6 +401,27 @@ DIST_EXPR = WRAPPED_DIST | DIST_CALL | UNKNOWN_WRAPPER | UNKNOWN_DIST
 DISTRIBUTION = IDENTIFIER("param_name") + TILDE - DIST_EXPR + pp.Optional(EQUALS + _DIST_NUMBER_EXPR)("initial") - SEMI
 
 
+def _missing_tilde_fail(s: str, loc: int, toks) -> None:
+    param_name = toks.param_name
+    dist_or_wrapper = toks.dist_or_wrapper
+    raise GCNParseFailure(
+        s,
+        loc,
+        f"Used '=' instead of '~' for distribution prior on '{param_name}'. "
+        f"Use '{param_name} ~ {dist_or_wrapper}(...)' instead of '{param_name} = {dist_or_wrapper}(...)'",
+        code=ErrorCode.E009,
+        found="=",
+    )
+
+
+MISSING_TILDE = (
+    IDENTIFIER("param_name")
+    + pp.FollowedBy(pp.Literal("=") + (WRAPPER_NAME | DIST_NAME))
+    + pp.Literal("=").suppress()
+    + (WRAPPER_NAME | DIST_NAME)("dist_or_wrapper")
+).set_parse_action(_missing_tilde_fail)
+
+
 def _build_distribution(tokens) -> GCNDistribution:
     param_name = tokens.param_name
     dist_name = tokens.dist_name
@@ -442,6 +471,7 @@ __all__ = [
     "DIST_EXPR",
     "EQUATION",
     "LAGRANGE_MULT",
+    "MISSING_TILDE",
     "TAG",
     "VARIABLE_LIST",
     "VARIABLE_REF",

--- a/gEconpy/parser/preprocessor.py
+++ b/gEconpy/parser/preprocessor.py
@@ -158,7 +158,7 @@ def preprocess_file(
         The parsing result containing AST and metadata.
     """
     filepath = Path(filepath)
-    content = filepath.read_text()
+    content = filepath.read_text(encoding="utf-8")
     return preprocess(content, filename=str(filepath), validate=validate)
 
 

--- a/tests/_resources/error_gcns/E009_equals_instead_of_tilde.expected
+++ b/tests/_resources/error_gcns/E009_equals_instead_of_tilde.expected
@@ -1,0 +1,13 @@
+error[E009]: Used '=' instead of '~' for distribution prior on 'beta'. Use 'beta ~ maxent(...)' instead of 'beta = maxent(...)'. Found '='
+  --> E009_equals_instead_of_tilde.gcn:10:9
+     |
+   8 |     calibration
+   9 |     {
+  10 |         beta = maxent(Beta(), lower=0.95, upper=0.999, mass=0.99) = 0.99;
+     |         ^ invalid distribution syntax
+  11 |     };
+  12 | };
+     |
+   = note: Use tilde for distributions: alpha ~ Beta(a=1, b=1)
+   = note: Check distribution name spelling
+   = note: Use '=' for fixed values, '~' for distributions

--- a/tests/_resources/error_gcns/E009_equals_instead_of_tilde.gcn
+++ b/tests/_resources/error_gcns/E009_equals_instead_of_tilde.gcn
@@ -1,0 +1,12 @@
+block HOUSEHOLD
+{
+    identities
+    {
+        Y[] = C[] + I[];
+    };
+
+    calibration
+    {
+        beta = maxent(Beta(), lower=0.95, upper=0.999, mass=0.99) = 0.99;
+    };
+};

--- a/tests/_resources/error_gcns/V001_dynamic_calibrating_equation.expected
+++ b/tests/_resources/error_gcns/V001_dynamic_calibrating_equation.expected
@@ -1,0 +1,11 @@
+error[V001]: Calibrating equation in block HOUSEHOLD uses non-steady-state variables
+  --> <source>:26:9
+     |
+  25 |         # This is wrong - should use K[ss] not K[]
+  26 |         K[] / Y[] = 10 -> K_to_Y;
+               ^^^^^^^^^^^^^^^ variables must use [ss] time index
+  27 |     };
+  28 | };
+     |
+   = note: Calibrating equations define steady-state relationships
+   = note: Use X[ss] instead of X[] for all variables

--- a/tests/_resources/error_gcns/V001_dynamic_calibrating_equation.gcn
+++ b/tests/_resources/error_gcns/V001_dynamic_calibrating_equation.gcn
@@ -1,0 +1,28 @@
+# Test file for DynamicCalibratingEquationException
+# Calibrating equation uses non-steady-state time index
+
+block HOUSEHOLD {
+    definitions {
+        u[] = C[] ^ (1 - sigma) / (1 - sigma);
+    };
+
+    controls {
+        C[];
+    };
+
+    objective {
+        U[] = u[] + beta * E[][U[1]];
+    };
+
+    constraints {
+        C[] + K[] = Y[] + (1 - delta) * K[-1];
+    };
+
+    calibration {
+        beta = 0.99;
+        sigma = 2.0;
+        delta = 0.025;
+        # This is wrong - should use K[ss] not K[]
+        K[] / Y[] = 10 -> K_to_Y;
+    };
+};

--- a/tests/_resources/error_gcns/V002_control_variable_not_found.expected
+++ b/tests/_resources/error_gcns/V002_control_variable_not_found.expected
@@ -1,0 +1,12 @@
+error[V002]: Control variable 'K_t' in block HOUSEHOLD not found in equations
+  --> <source>:6:9
+     |
+  5 |     controls {
+  6 |         K[];
+              ^^^ undeclared control variable
+  7 |     };
+  8 |
+     |
+   = note: Control variables must appear in the objective or constraints
+   = note: Check spelling of the variable name
+   = note: Verify the variable has the correct time index

--- a/tests/_resources/error_gcns/V002_control_variable_not_found.gcn
+++ b/tests/_resources/error_gcns/V002_control_variable_not_found.gcn
@@ -1,0 +1,12 @@
+# Test file for ControlVariableNotFoundException
+# Control variable K[] is declared but not used in any equations
+
+block HOUSEHOLD {
+    controls {
+        K[];
+    };
+
+    objective {
+        U[] = C[];
+    };
+};

--- a/tests/_resources/error_gcns/V003_duplicate_parameter.expected
+++ b/tests/_resources/error_gcns/V003_duplicate_parameter.expected
@@ -1,0 +1,11 @@
+error[V003]: Duplicate parameter declaration in block HOUSEHOLD
+  --> <source>:24:9
+     |
+  23 |         beta = 0.99;
+  24 |         alpha = 0.5;
+               ^^^^^^^^^^^^ 'alpha' already defined
+  25 |     };
+  26 | };
+     |
+   = note: Each parameter should be declared only once
+   = note: Remove the duplicate declaration

--- a/tests/_resources/error_gcns/V003_duplicate_parameter.gcn
+++ b/tests/_resources/error_gcns/V003_duplicate_parameter.gcn
@@ -1,0 +1,26 @@
+# Test file for DuplicateParameterError
+# Parameter alpha is defined twice
+
+block HOUSEHOLD {
+    definitions {
+        u[] = C[] ^ (1 - sigma) / (1 - sigma);
+    };
+
+    controls {
+        C[];
+    };
+
+    objective {
+        U[] = u[] + beta * E[][U[1]];
+    };
+
+    constraints {
+        C[] = Y[];
+    };
+
+    calibration {
+        alpha = 0.33;
+        beta = 0.99;
+        alpha = 0.5;
+    };
+};

--- a/tests/_resources/error_gcns/syntax_unopened_parenthesis.expected
+++ b/tests/_resources/error_gcns/syntax_unopened_parenthesis.expected
@@ -1,13 +1,13 @@
-error[E001]: Missing semicolon. Found ''U''
-  --> syntax_unopened_parenthesis.gcn:6:9
+error[E007]: Unmatched ')' — extra closing bracket with no matching opener. Found ')'
+  --> syntax_unopened_parenthesis.gcn:6:24
      |
    4 |     identities
    5 |     {
    6 |         U[] = C[] + I[]);
-     |         ^ missing semicolon
+     |                        ^ unbalanced parentheses
    7 |     };
    8 | };
      |
-   = note: Add ';' at the end of the statement
-   = note: Check that each equation ends with ';'
-   = note: Check that each block component ends with '};'
+   = note: Count opening and closing parentheses
+   = note: Check function calls have closing ')'
+   = note: Use an editor with parenthesis matching

--- a/tests/parser/grammar/test_components.py
+++ b/tests/parser/grammar/test_components.py
@@ -332,3 +332,27 @@ class TestComponentErrors:
         # controls expects variable list, not equation
         with pytest.raises(pp.ParseBaseException):
             CONTROLS.parse_string("controls { Y[] = C[]; };")
+
+    def test_equals_instead_of_tilde_with_wrapper(self):
+        text = """calibration
+        {
+            beta = maxent(Beta(), lower=0.95, upper=0.999, mass=0.99) = 0.99;
+        };"""
+        with pytest.raises(pp.ParseFatalException, match="instead of '~'"):
+            CALIBRATION.parse_string(text)
+
+    def test_equals_instead_of_tilde_with_bare_dist(self):
+        text = """calibration
+        {
+            alpha = Beta(alpha=2, beta=5) = 0.35;
+        };"""
+        with pytest.raises(pp.ParseFatalException, match="instead of '~'"):
+            CALIBRATION.parse_string(text)
+
+    def test_equals_instead_of_tilde_error_code(self):
+        text = """calibration
+        {
+            beta = maxent(Beta(), lower=0.95, upper=0.999, mass=0.99) = 0.99;
+        };"""
+        with pytest.raises(pp.ParseFatalException, match="E009"):
+            CALIBRATION.parse_string(text)

--- a/tests/parser/grammar/test_gcn_file.py
+++ b/tests/parser/grammar/test_gcn_file.py
@@ -371,7 +371,7 @@ class TestParseGCNFiles:
         if not gcn_path.exists():
             pytest.skip(f"Test file not found: {gcn_path}")
 
-        text = gcn_path.read_text()
+        text = gcn_path.read_text(encoding="utf-8")
         model = parse_gcn(text)
 
         assert len(model.blocks) == 1
@@ -382,7 +382,7 @@ class TestParseGCNFiles:
         if not gcn_path.exists():
             pytest.skip(f"Test file not found: {gcn_path}")
 
-        text = gcn_path.read_text()
+        text = gcn_path.read_text(encoding="utf-8")
         model = parse_gcn(text)
 
         assert len(model.blocks) >= 2
@@ -394,7 +394,7 @@ class TestParseGCNFiles:
         if not gcn_path.exists():
             pytest.skip(f"Test file not found: {gcn_path}")
 
-        text = gcn_path.read_text()
+        text = gcn_path.read_text(encoding="utf-8")
         model = parse_gcn(text)
 
         assert isinstance(model, GCNModel)

--- a/tests/parser/test_expected_errors.py
+++ b/tests/parser/test_expected_errors.py
@@ -1,5 +1,3 @@
-import sys
-
 from difflib import unified_diff
 from pathlib import Path
 
@@ -41,14 +39,14 @@ def get_validation_error_test_cases():
 )
 def test_parse_error_output_matches_golden_file(name, gcn_file, expected_file):
     """Test that parse errors (Exxx) match expected output."""
-    content = gcn_file.read_text()
+    content = gcn_file.read_text(encoding="utf-8")
     formatter = ErrorFormatter(use_color=False)
 
     with pytest.raises(GCNParseError) as exc_info:
         preprocess(content, validate=True, filename=gcn_file.name)
 
     actual_output = formatter.format_error(exc_info.value, content)
-    expected_output = expected_file.read_text().rstrip("\n")
+    expected_output = expected_file.read_text(encoding="utf-8").rstrip("\n")
 
     if actual_output != expected_output:
         _print_diff(actual_output, expected_output, name)
@@ -65,7 +63,7 @@ def test_validation_error_output_matches_golden_file(name, gcn_file, expected_fi
         load_gcn_file(str(gcn_file))
 
     actual_output = str(exc_info.value)
-    expected_output = expected_file.read_text().rstrip("\n")
+    expected_output = expected_file.read_text(encoding="utf-8").rstrip("\n")
 
     if actual_output != expected_output:
         _print_diff(actual_output, expected_output, name)


### PR DESCRIPTION
Better error reporting for:

- Incorrect operator after distribution: `x = Normal(0, 1);` instead of `x ~ Normal(0, 1);`
- Mismatched parenthesis: a + b); instead of (a + b)

<!-- readthedocs-preview gEconpy start -->
----
📚 Documentation preview 📚: https://gEconpy--81.org.readthedocs.build/en/81/

<!-- readthedocs-preview gEconpy end -->