### PR TITLE
Add textmate support for highlighting pairs of closures

### DIFF
--- a/gcn.tmbundle/Preferences/gcn.tmPreferences
+++ b/gcn.tmbundle/Preferences/gcn.tmPreferences
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>name</key>
+    <string>GCN Preferences</string>
+
+    <key>scope</key>
+    <string>source.gcn</string>
+
+    <key>settings</key>
+    <dict>
+      <key>highlightPairs</key>
+      <array>
+        <array>
+          <string>(</string>
+          <string>)</string>
+        </array>
+        <array>
+          <string>[</string>
+          <string>]</string>
+        </array>
+        <array>
+          <string>{</string>
+          <string>}</string>
+        </array>
+      </array>
+
+      <key>smartTypingPairs</key>
+      <array>
+        <array>
+          <string>(</string>
+          <string>)</string>
+        </array>
+        <array>
+          <string>[</string>
+          <string>]</string>
+        </array>
+        <array>
+          <string>{</string>
+          <string>}</string>
+        </array>
+      </array>
+    </dict>
+
+    <key>uuid</key>
+    <string>A1B2C3D4-5678-9ABC-DEF0-123456789ABC</string>
+  </dict>
+</plist>

--- a/gcn.tmbundle/Syntaxes/gcn.tmLanguage.json
+++ b/gcn.tmbundle/Syntaxes/gcn.tmLanguage.json
@@ -1,5 +1,3 @@
-    { "include": "#curly-braces" },
-    { "include": "#round-parens" },
 {
   "name": "GCN",
   "scopeName": "source.gcn",

--- a/gcn.tmbundle/Syntaxes/gcn.tmLanguage.json
+++ b/gcn.tmbundle/Syntaxes/gcn.tmLanguage.json
@@ -12,6 +12,8 @@
     { "include": "#expectation-operator" },
     { "include": "#distribution" },
     { "include": "#variable-with-time" },
+    { "include": "#curly-braces" },
+    { "include": "#round-parens" },
     { "include": "#number" }
   ],
   "repository": {
@@ -68,8 +70,36 @@
       "match": "\\b([A-Za-z_][A-Za-z0-9_]*)\\s*(\\[)\\s*(-?\\d+|ss)?\\s*(\\])",
       "captures": {
         "1": { "name": "entity.name.function.gcn" },
-        "3": { "name": "constant.numeric.gcn" }
+        "2": { "name": "punctuation.definition.brackets.begin.gcn" },
+        "3": { "name": "constant.numeric.gcn" },
+        "4": { "name": "punctuation.definition.brackets.end.gcn" }
       }
+    },
+
+    "curly-braces": {
+      "patterns": [
+        {
+          "name": "punctuation.definition.block.begin.gcn",
+          "match": "\\{"
+        },
+        {
+          "name": "punctuation.definition.block.end.gcn",
+          "match": "\\}"
+        }
+      ]
+    },
+
+    "round-parens": {
+      "patterns": [
+        {
+          "name": "punctuation.definition.arguments.begin.gcn",
+          "match": "\\("
+        },
+        {
+          "name": "punctuation.definition.arguments.end.gcn",
+          "match": "\\)"
+        }
+      ]
     },
 
     "number": {

--- a/gcn.tmbundle/Syntaxes/gcn.tmLanguage.json
+++ b/gcn.tmbundle/Syntaxes/gcn.tmLanguage.json
@@ -1,3 +1,5 @@
+    { "include": "#curly-braces" },
+    { "include": "#round-parens" },
 {
   "name": "GCN",
   "scopeName": "source.gcn",


### PR DESCRIPTION
When the cursor is next to a closure like '(', '{', or '[', it should highlight the other one. Makes it easier to find deep nests of parenthesis.

<!-- readthedocs-preview gEconpy start -->
----
📚 Documentation preview 📚: https://gEconpy--82.org.readthedocs.build/en/82/

<!-- readthedocs-preview gEconpy end -->