### PR TITLE
Symbolic linearize and blanchard-khan conditions

### DIFF
--- a/conda_envs/environment_dev.yml
+++ b/conda_envs/environment_dev.yml
@@ -54,7 +54,7 @@ dependencies:
 
   - pip:
       - numdifftools
-      - jax>0.8<0.9.1
+      - jax>0.8,<0.9.1
       - flowjax
       - corner
       - asv

--- a/gEconpy/__init__.py
+++ b/gEconpy/__init__.py
@@ -6,7 +6,6 @@ from importlib.metadata import version
 from gEconpy import (
     classes,
     data,
-    exceptions,
     parser,
     plotting,
     solvers,

--- a/gEconpy/__init__.py
+++ b/gEconpy/__init__.py
@@ -6,6 +6,7 @@ from importlib.metadata import version
 from gEconpy import (
     classes,
     data,
+    exceptions,
     parser,
     plotting,
     solvers,
@@ -28,6 +29,8 @@ from gEconpy.model.statistics import (
 )
 from gEconpy.model.steady_state import print_steady_state
 from gEconpy.parser.html import print_gcn_file
+from gEconpy.pytensorf.real import *  # noqa: F403
+from gEconpy.pytensorf.real_eig import *  # noqa: F403
 
 _log = logging.getLogger(__name__)
 

--- a/gEconpy/model/model.py
+++ b/gEconpy/model/model.py
@@ -1046,6 +1046,117 @@ class Model:
 
         return res, compiled_funcs
 
+    def symbolic_linearization(
+        self,
+        order: Literal[1] = 1,
+        log_linearize: bool = True,
+        not_loglin_variables: list[str] | None = None,
+        steady_state: dict | None = None,
+        loglin_negative_ss: bool = False,
+        verbose: bool = True,
+    ) -> tuple[list[TensorVariable], list[TensorVariable], list[TensorVariable]]:
+        r"""
+        Return the symbolic pytensor graphs for the linearized Jacobian matrices.
+
+        Builds (and caches) the four Jacobian matrices ``A, B, C, D`` as pytensor graph nodes representing the
+        first-order approximation of the model around its steady state:
+
+        .. math::
+            A \hat{y}_{t-1} + B \hat{y}_t + C \hat{y}_{t+1} + D \varepsilon_t = 0
+
+        Unlike :meth:`linearize_model`, this method does **not** compile or numerically evaluate the graphs. The
+        returned nodes can be inspected, manipulated, or compiled by the caller.
+
+        Parameters
+        ----------
+        order : int, default 1
+            Order of the Taylor expansion. Only ``order=1`` is currently supported.
+        log_linearize : bool, default True
+            If True, all variables are log-linearized. If False, all variables are left in levels.
+        not_loglin_variables : list of str, optional
+            Variable names to exclude from log-linearization. Ignored if ``log_linearize`` is False.
+        steady_state : dict, optional
+            Steady-state values used to determine which variables have non-positive steady states (and therefore
+            cannot be log-linearized). If not provided, the steady state is solved internally.
+        loglin_negative_ss : bool, default False
+            If True, variables with negative steady-state values are still log-linearized.
+        verbose : bool, default True
+            Log warnings about excluded variables.
+
+        Returns
+        -------
+        jacobians : list of TensorVariable
+            Four pytensor matrix graph nodes ``[A, B, C, D]``.
+        ss_input_nodes : list of TensorVariable
+            Steady-state variable input nodes consumed by the Jacobian graphs.
+        param_input_nodes : list of TensorVariable
+            Parameter input nodes consumed by the Jacobian graphs (discovered via ``explicit_graph_inputs``).
+
+        See Also
+        --------
+        linearize_model : Compile and numerically evaluate the linearized system.
+
+        Examples
+        --------
+        .. code-block:: python
+
+            model = model_from_gcn("rbc.gcn")
+            jacobians, ss_nodes, param_nodes = model.symbolic_linearization()
+            A, B, C, D = jacobians
+
+            # Inspect the pytensor graph
+            import pytensor
+
+            pytensor.dprint(A)
+        """
+        if order != 1:
+            raise NotImplementedError("Only first order linearization is currently supported.")
+
+        if self.is_linear:
+            log_linearize = False
+
+        # A steady state is only needed to decide loglin flags (sign / near-zero checks).
+        # If not provided, solve for one using default parameters.
+        if steady_state is None and log_linearize:
+            if self.is_linear:
+                steady_state = self.f_ss(**self.parameters())
+            else:
+                steady_state = self.steady_state(**self.parameters(), verbose=verbose)
+
+        not_loglin_flags = make_not_loglin_flags(
+            variables=self.variables,
+            calibrated_params=self.calibrated_params,
+            steady_state=steady_state if steady_state is not None else {},
+            log_linearize=log_linearize,
+            not_loglin_variables=not_loglin_variables,
+            loglin_negative_ss=loglin_negative_ss,
+            verbose=verbose,
+        )
+
+        loglin_vars = [v for v, flag in zip(self.variables, not_loglin_flags, strict=False) if flag == 0]
+        loglin_key = frozenset(v.base_name for v in loglin_vars)
+
+        if not hasattr(self, "_symbolic_linearize_cache"):
+            self._symbolic_linearize_cache = {}
+
+        if loglin_key not in self._symbolic_linearize_cache:
+            jacobians, ss_input_nodes = _linearize_model(
+                variables=self.variables,
+                equations=self.equations,
+                shocks=self.shocks,
+                cache=self._ensure_cache(),
+                loglin_variables=loglin_vars,
+            )
+
+            ss_names = {n.name for n in ss_input_nodes}
+            param_input_nodes = [
+                v for v in explicit_graph_inputs(jacobians) if v.name is not None and v.name not in ss_names
+            ]
+
+            self._symbolic_linearize_cache[loglin_key] = (jacobians, ss_input_nodes, param_input_nodes)
+
+        return self._symbolic_linearize_cache[loglin_key]
+
     def linearize_model(
         self,
         order: Literal[1] = 1,
@@ -1193,52 +1304,33 @@ class Model:
                     **steady_state_kwargs,
                 )
 
-        not_loglin_flags = make_not_loglin_flags(
-            variables=self.variables,
-            calibrated_params=self.calibrated_params,
-            steady_state=steady_state,
+        jacobians, ss_input_nodes, param_input_nodes = self.symbolic_linearization(
+            order=order,
             log_linearize=log_linearize,
             not_loglin_variables=not_loglin_variables,
+            steady_state=steady_state,
             loglin_negative_ss=loglin_negative_ss,
             verbose=verbose,
         )
 
-        # Convert flag array to a list of variables to log-linearize
-        loglin_vars = [v for v, flag in zip(self.variables, not_loglin_flags, strict=False) if flag == 0]
-        loglin_key = frozenset(v.base_name for v in loglin_vars)
+        # Cache the compiled function. Since symbolic_linearization returns the same graph objects on cache hit,
+        # the id of the first jacobian node is a stable key.
+        cache_key = id(jacobians[0])
 
-        # Cache the compiled linearization function keyed by the loglin variable set.
-        # The pytensor graph and compiled function are expensive to build but identical
-        # across calls with the same loglin set — only the input values change.
         if not hasattr(self, "_linearize_cache"):
             self._linearize_cache = {}
 
-        if loglin_key not in self._linearize_cache:
-            jacobians, ss_input_nodes = _linearize_model(
-                variables=self.variables,
-                equations=self.equations,
-                shocks=self.shocks,
-                cache=self._ensure_cache(),
-                loglin_variables=loglin_vars,
-            )
-
-            # Discover all graph inputs. ss_input_nodes are the steady-state variable nodes; remaining inputs are
-            # parameters (free, deterministic, or calibrated) that the equations reference.
-            ss_names = {n.name for n in ss_input_nodes}
-            all_graph_inputs = [
-                v for v in explicit_graph_inputs(jacobians) if v.name is not None and v.name not in ss_names
-            ]
-
-            all_inputs = ss_input_nodes + all_graph_inputs
-            f = compile_pytensor_function(all_inputs, jacobians, on_unused_input="ignore", mode=self._mode)
-            self._linearize_cache[loglin_key] = (f, all_graph_inputs)
+        if cache_key not in self._linearize_cache:
+            all_inputs = list(ss_input_nodes) + list(param_input_nodes)
+            f = compile_pytensor_function(all_inputs, jacobians, on_unused_input="ignore")
+            self._linearize_cache[cache_key] = f
         else:
-            f, all_graph_inputs = self._linearize_cache[loglin_key]
+            f = self._linearize_cache[cache_key]
 
         # Build input values: steady-state variables first, then parameters in graph order
         ss_values = {k.removesuffix("_ss"): v for k, v in steady_state.items()}
         ss_vals = [ss_values[v.base_name] for v in self.variables]
-        param_vals = [param_dict[n.name] for n in all_graph_inputs]
+        param_vals = [param_dict[n.name] for n in param_input_nodes]
 
         A, B, C, D = f(*ss_vals, *param_vals)
 

--- a/gEconpy/model/model.py
+++ b/gEconpy/model/model.py
@@ -451,6 +451,45 @@ class Model:
         """List of model equations, evaluated at the deterministic steady state."""
         return self._steady_state_relationships
 
+    @property
+    def n_variables(self) -> int:
+        """Number of endogenous variables in the model."""
+        return len(self._variables)
+
+    @property
+    def backward_variables(self) -> list[TimeAwareSymbol]:
+        """Variables that appear at t-1 in at least one equation (state variables)."""
+        if not hasattr(self, "_backward_variables"):
+            lagged = {a.set_t(0) for eq in self._equations for a in eq.atoms(TimeAwareSymbol) if a.time_index == -1}
+            self._backward_variables = [v for v in self._variables if v in lagged]
+        return self._backward_variables
+
+    @property
+    def forward_variables(self) -> list[TimeAwareSymbol]:
+        """Variables that appear at t+1 in at least one equation (forward-looking/jump variables)."""
+        if not hasattr(self, "_forward_variables"):
+            leads = {a.set_t(0) for eq in self._equations for a in eq.atoms(TimeAwareSymbol) if a.time_index == 1}
+            self._forward_variables = [v for v in self._variables if v in leads]
+        return self._forward_variables
+
+    @property
+    def n_backward(self) -> int:
+        """Number of backward-looking (state) variables."""
+        return len(self.backward_variables)
+
+    @property
+    def n_forward(self) -> int:
+        """Number of forward-looking (jump) variables."""
+        return len(self.forward_variables)
+
+    @property
+    def lead_var_idx(self) -> np.ndarray:
+        """Column indices of forward-looking variables in the Jacobian matrices."""
+        if not hasattr(self, "_lead_var_idx"):
+            fwd_set = set(self.forward_variables)
+            self._lead_var_idx = np.array([i for i, v in enumerate(self._variables) if v in fwd_set], dtype=int)
+        return self._lead_var_idx
+
     def parameters(self, **updates: float) -> SymbolDictionary[str, float]:
         """
         Compute the full set of free parameters for the model, including deterministic parameters.

--- a/gEconpy/model/perturbation.py
+++ b/gEconpy/model/perturbation.py
@@ -8,8 +8,6 @@ import pytensor.tensor as pt
 import sympy as sp
 
 from pymc.pytensorf import rewrite_pregrad
-from pytensor.graph.basic import Apply
-from pytensor.graph.op import Op
 from pytensor.graph.replace import graph_replace
 from pytensor.tensor import TensorVariable
 from scipy import linalg
@@ -18,6 +16,7 @@ from sympytensor import as_tensor
 from gEconpy.classes.containers import SymbolDictionary
 from gEconpy.classes.time_aware_symbol import TimeAwareSymbol
 from gEconpy.model.timing import make_all_variable_time_combinations
+from gEconpy.pytensorf.real_eig import real_eig
 from gEconpy.pytensorf.sparse_jacobian import sparse_jacobian
 from gEconpy.solvers.gensys import _gensys_setup
 from gEconpy.utilities import get_name
@@ -363,17 +362,100 @@ def check_perturbation_solution(
     _log.info(f"Norm of stochastic part:    {norm_stoch:0.9f}")
 
 
-def _compute_solution_eigenvalues(
+def compute_bk_eigenvalues(
     A: np.ndarray, B: np.ndarray, C: np.ndarray, D: np.ndarray, tol: float = 1e-8
-) -> np.ndarray:
-    """Compute sorted generalized eigenvalues of the linearized system via ordered QZ decomposition."""
+) -> tuple[np.ndarray, np.ndarray, int]:
+    """Compute generalized eigenvalues of the linearized DSGE system for BK condition analysis.
+
+    Builds the Sims (2002) augmented system and computes eigenvalues via ordered QZ decomposition.
+    Eigenvalues are sorted by ascending modulus.
+
+    Parameters
+    ----------
+    A, B, C, D : np.ndarray
+        Jacobian matrices of the linearized DSGE system.
+    tol : float, default 1e-8
+        Tolerance for identifying forward-looking variables.
+
+    Returns
+    -------
+    eigvals_real : np.ndarray
+        Real parts of eigenvalues, sorted by modulus.
+    eigvals_imag : np.ndarray
+        Imaginary parts of eigenvalues, sorted by modulus.
+    n_forward : int
+        Number of forward-looking variables (columns of C with nonzero entries).
+    """
     Gamma_0, Gamma_1, _, _, _ = _gensys_setup(A, B, C, D, tol)
     AA, BB, *_ = linalg.ordqz(-Gamma_0, Gamma_1, sort="ouc", output="complex")
 
     eigenvalues = np.diag(BB) / (np.diag(AA) + tol)
+    idx = np.argsort(np.abs(eigenvalues))
+    eigenvalues = eigenvalues[idx]
 
-    eig = np.column_stack([np.abs(eigenvalues), np.real(eigenvalues), np.imag(eigenvalues)])
-    return eig[np.argsort(eig[:, 0]), :]
+    n_forward = (np.abs(C).sum(axis=0) > tol).sum().astype(int)
+
+    return np.real(eigenvalues), np.imag(eigenvalues), n_forward
+
+
+def compute_bk_eigenvalues_pt(
+    A: TensorVariable,
+    B: TensorVariable,
+    C: TensorVariable,
+    _D: TensorVariable,
+    lead_var_idx: np.ndarray,
+) -> tuple[TensorVariable, TensorVariable]:
+    """Compute symbolic eigenvalues of the linearized DSGE system for BK condition analysis.
+
+    Builds the Sims (2002) augmented system symbolically and computes eigenvalues via
+    ``real_eig``. The result is differentiable with respect to the input matrices.
+
+    Parameters
+    ----------
+    A, B, C, _D : TensorVariable
+        Jacobian matrices of the linearized DSGE system.
+    lead_var_idx : np.ndarray of int
+        Column indices of forward-looking variables (columns of C with nonzero entries).
+        Must be known at graph-build time.
+
+    Returns
+    -------
+    eigvals_real : TensorVariable
+        Real parts of eigenvalues, sorted by modulus.
+    eigvals_imag : TensorVariable
+        Imaginary parts of eigenvalues, sorted by modulus.
+    """
+    lead_var_idx = np.asarray(lead_var_idx)
+    n_vars = A.type.shape[0]
+    if n_vars is None:
+        raise ValueError("A must have a known static shape for symbolic BK eigenvalue computation.")
+
+    I_n = pt.eye(n_vars)
+    Z_n = pt.zeros((n_vars, n_vars))
+
+    # Build augmented matrices (Sims 2002 form)
+    Gamma_0 = pt.vertical_stack(
+        pt.horizontal_stack(B, C),
+        pt.horizontal_stack(-I_n, Z_n),
+    )
+    Gamma_1 = pt.vertical_stack(
+        pt.horizontal_stack(A, Z_n),
+        pt.horizontal_stack(Z_n, I_n),
+    )
+
+    # Row/column selection matching _gensys_setup:
+    # all equation rows (0..n-1) + auxiliary rows for lead variables (n + lead_var_idx)
+    eqs_and_leads_idx = np.concatenate([np.arange(n_vars), lead_var_idx + n_vars])
+    Gamma_0_sel = Gamma_0[eqs_and_leads_idx, :][:, eqs_and_leads_idx]
+    Gamma_1_sel = Gamma_1[eqs_and_leads_idx, :][:, eqs_and_leads_idx]
+
+    # Gamma_0 may be singular (rank-deficient). Regularize with eps*I so that
+    # infinite eigenvalues become O(1/eps) — still correctly counted as unstable —
+    # while finite eigenvalues near |λ|=1 are perturbed by only O(eps).
+    n_sel = len(eqs_and_leads_idx)
+    G0_reg = -Gamma_0_sel + pt.eye(n_sel) * _FLOAT_ZERO_TOL
+    M = pt.linalg.solve(G0_reg, Gamma_1_sel)
+    return real_eig(M)
 
 
 def check_bk_condition(
@@ -425,9 +507,9 @@ def check_bk_condition(
     if return_value not in ["dataframe", "bool", None]:
         raise ValueError(f'Unknown return type "{return_value}"')
 
-    n_forward = (np.abs(C).sum(axis=0) > tol).sum().astype(int)
-    eig = pd.DataFrame(_compute_solution_eigenvalues(A, B, C, D, tol), columns=["Modulus", "Real", "Imaginary"])
-    n_unstable = (eig["Modulus"] > 1).sum()
+    eigvals_real, eigvals_imag, n_forward = compute_bk_eigenvalues(A, B, C, D, tol)
+    modulus = np.sqrt(eigvals_real**2 + eigvals_imag**2)
+    n_unstable = (modulus > 1).sum()
     satisfied = n_forward == n_unstable
 
     message = (
@@ -450,35 +532,8 @@ def check_bk_condition(
     if return_value is None:
         return None
     if return_value == "dataframe":
-        return eig
+        return pd.DataFrame({"Modulus": modulus, "Real": eigvals_real, "Imaginary": eigvals_imag})
     return satisfied
-
-
-class BlanchardKahnCondition(Op):
-    """Pytensor Op wrapping the Blanchard-Kahn eigenvalue check for use in computation graphs."""
-
-    def __init__(self, tol: float = 1e-8):
-        self.tol = tol
-        super().__init__()
-
-    def make_node(self, A, B, C, D) -> Apply:
-        inputs = list(map(pt.as_tensor, [A, B, C, D]))
-        outputs = [
-            pt.scalar("bk_flag", dtype=bool),
-            pt.scalar("n_forward", dtype=int),
-            pt.scalar("n_unstable", dtype=int),
-        ]
-        return Apply(self, inputs, outputs)
-
-    def perform(self, node: Apply, inputs: list[np.ndarray], outputs: list[list[None]]) -> None:
-        A, B, C, D = inputs
-        n_forward = (np.abs(C).sum(axis=0) > _FLOAT_ZERO_TOL).sum().astype(int)
-        eig = check_bk_condition(A, B, C, D, tol=self.tol, verbose=False, return_value="dataframe")
-        n_unstable = (eig["Modulus"] > 1).sum()
-
-        outputs[0][0] = np.array(n_forward != n_unstable)
-        outputs[1][0] = np.array(n_forward)
-        outputs[2][0] = np.array(n_unstable)
 
 
 def check_bk_condition_pt(
@@ -486,32 +541,32 @@ def check_bk_condition_pt(
     B: TensorVariable,
     C: TensorVariable,
     D: TensorVariable,
-    tol: float = 1e-8,
+    lead_var_idx: np.ndarray,
 ) -> tuple[TensorVariable, TensorVariable, TensorVariable]:
     r"""
-    Pytensor wrapper for the Blanchard-Kahn condition check.
+    Symbolic Blanchard-Kahn condition check using differentiable eigenvalues.
 
     Parameters
     ----------
     A, B, C, D : TensorVariable
         Jacobian matrices of the linearized DSGE system.
-    tol : float, default 1e-8
-        Tolerance below which numerical values are considered zero.
+    lead_var_idx : np.ndarray of int
+        Column indices of forward-looking variables. Must be known at graph-build time.
 
     Returns
     -------
-    bk_flag : TensorVariable (bool scalar)
-        True if the condition is **not** satisfied.
+    bk_satisfied : TensorVariable (bool scalar)
+        True if the Blanchard-Kahn condition IS satisfied.
     n_forward : TensorVariable (int scalar)
         Number of forward-looking variables.
     n_unstable : TensorVariable (int scalar)
         Number of eigenvalues with modulus greater than one.
-
-    References
-    ----------
-    .. [1] Sims, Christopher A. "Solving linear rational expectations models."
-       *Computational Economics* 20.1-2 (2002): 1-20.
-    .. [2] Blanchard, O.J. and Kahn, C.M. "The solution of linear difference models under
-       rational expectations." *Econometrica* 48.5 (1980): 1305-1311.
     """
-    return BlanchardKahnCondition(tol=tol)(A, B, C, D)
+    lead_var_idx = np.asarray(lead_var_idx)
+    n_forward = len(lead_var_idx)
+    eigvals_real, eigvals_imag = compute_bk_eigenvalues_pt(A, B, C, D, lead_var_idx)
+    modulus = pt.sqrt(eigvals_real**2 + eigvals_imag**2)
+    n_unstable = (modulus > 1).sum()
+    bk_satisfied = pt.eq(n_forward, n_unstable)
+
+    return bk_satisfied, pt.constant(n_forward), n_unstable

--- a/gEconpy/model/statespace.py
+++ b/gEconpy/model/statespace.py
@@ -140,6 +140,7 @@ class DSGEStateSpace(PyMCStateSpace):
         self._bk_output = None
         self._policy_resid = None
         self._n_steps = None
+        self._lead_var_idx: np.ndarray | None = None
 
         self.verbose = verbose
 
@@ -175,6 +176,22 @@ class DSGEStateSpace(PyMCStateSpace):
             self._n_steps = n_steps
 
         return T, R
+
+    @property
+    def lead_var_idx(self) -> np.ndarray:
+        """Column indices of forward-looking variables (variables appearing at t+1 in any equation)."""
+        if self._lead_var_idx is None:
+            idx = []
+            for i, v in enumerate(self.variables):
+                if any(eq.has(v.set_t(1)) for eq in self.equations):
+                    idx.append(i)
+            self._lead_var_idx = np.array(idx, dtype=int)
+        return self._lead_var_idx
+
+    @property
+    def n_forward(self) -> int:
+        """Number of forward-looking variables."""
+        return len(self.lead_var_idx)
 
     def _setup_state_covariance(self):
         if self.full_covariance:
@@ -224,7 +241,7 @@ class DSGEStateSpace(PyMCStateSpace):
             self.linearized_system, constant_replacements, strict=False
         )
 
-        self._bk_output = check_bk_condition_pt(A, B, C, D)
+        self._bk_output = check_bk_condition_pt(A, B, C, D, lead_var_idx=self.lead_var_idx)
 
         T, R = self._setup_policy_matrices(A, B, C, D)
         resid = pt.square(A + B @ T + C @ T @ T).sum()
@@ -448,7 +465,7 @@ class DSGEStateSpace(PyMCStateSpace):
             strict=False,
         )
 
-        bk_flag, _n_forward, _n_gt_one = bk_output
+        bk_satisfied, _n_forward, _n_gt_one = bk_output
 
         if add_norm_check:
             n_vars, n_shocks = R.shape
@@ -482,8 +499,8 @@ class DSGEStateSpace(PyMCStateSpace):
             )
 
         if add_bk_check:
-            pm.Deterministic("bk_flag", bk_flag)
-            pm.Potential("bk_condition_satisfied", pt.switch(pt.eq(bk_flag, 1.0), 0.0, -np.inf))
+            pm.Deterministic("bk_satisfied", bk_satisfied)
+            pm.Potential("bk_condition_satisfied", pt.switch(pt.eq(bk_satisfied, 0.0), -np.inf, 0.0))
 
         if add_solver_success_check:
             policy_resid = pm.Deterministic("policy_resid", policy_resid)

--- a/gEconpy/model/statistics/__init__.py
+++ b/gEconpy/model/statistics/__init__.py
@@ -5,7 +5,11 @@ from gEconpy.model.statistics.covariance import (
     stationary_covariance_matrix,
 )
 from gEconpy.model.statistics.formatting import matrix_to_dataframe
-from gEconpy.model.statistics.perturbation_diagnostics import check_bk_condition, summarize_perturbation_solution
+from gEconpy.model.statistics.perturbation_diagnostics import (
+    check_bk_condition,
+    eigenvalue_sensitivity,
+    summarize_perturbation_solution,
+)
 from gEconpy.model.statistics.validation import (
     _maybe_linearize_model,
     _maybe_solve_model,
@@ -26,6 +30,7 @@ __all__ = [
     "build_Q_matrix",
     "check_bk_condition",
     "check_steady_state",
+    "eigenvalue_sensitivity",
     "matrix_to_dataframe",
     "stationary_covariance_matrix",
     "summarize_perturbation_solution",

--- a/gEconpy/model/statistics/perturbation_diagnostics.py
+++ b/gEconpy/model/statistics/perturbation_diagnostics.py
@@ -1,18 +1,31 @@
 from __future__ import annotations
 
+import logging
+
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 import pandas as pd
+import pytensor
+import pytensor.tensor as pt
 import xarray as xr
 
+from pymc.pytensorf import rewrite_pregrad
+
 from gEconpy.exceptions import PerturbationSolutionNotFoundException
-from gEconpy.model.perturbation import check_bk_condition as _check_bk_condition
+from gEconpy.model.perturbation import (
+    check_bk_condition as _check_bk_condition,
+)
+from gEconpy.model.perturbation import (
+    compute_bk_eigenvalues_pt,
+)
 from gEconpy.model.statistics.validation import _maybe_linearize_model
 
 if TYPE_CHECKING:
     from gEconpy.model.model import Model
+
+_log = logging.getLogger(__name__)
 
 
 def summarize_perturbation_solution(
@@ -92,4 +105,118 @@ def check_bk_condition(
         verbose=verbose,
         on_failure=on_failure,
         return_value=return_value,
+    )
+
+
+def eigenvalue_sensitivity(
+    model: Model,
+    *,
+    verbose: bool = True,
+    steady_state: dict | None = None,
+    steady_state_kwargs: dict | None = None,
+    **parameter_updates,
+) -> xr.Dataset:
+    r"""
+    Compute the sensitivity of system eigenvalues to model parameters.
+
+    For each eigenvalue of the linearized DSGE system's augmented form, computes the derivative
+    of the real and imaginary parts with respect to every free parameter. This reveals which
+    parameters push eigenvalues toward or away from the unit circle, potentially moving the
+    model in or out of Blanchard-Kahn stability.
+
+    Parameters
+    ----------
+    model : Model
+        A gEconpy DSGE model.
+    verbose : bool, default True
+        Forwarded to steady-state and linearization routines.
+    steady_state : dict, optional
+        Pre-computed steady state. If not provided, solved internally.
+    steady_state_kwargs : dict, optional
+        Keyword arguments forwarded to ``model.steady_state``.
+    **parameter_updates
+        Parameter overrides (e.g. ``beta=0.98``).
+
+    Returns
+    -------
+    xr.Dataset
+        Dataset with two data variables:
+
+        - ``eigenvalues`` : shape ``(eigenvalue, component)`` where ``component`` is
+          ``[real, imaginary, modulus]``.
+        - ``gradients`` : shape ``(eigenvalue, part, parameter)`` where ``part`` is
+          ``[real, imaginary]``.
+
+    Notes
+    -----
+    Eigenvalues are computed from the Sims (2002) augmented system via the ``real_eig`` Op,
+    which provides exact reverse-mode gradients.
+
+    Eigenvalues are sorted by modulus (ascending), so zeros appear first and large/infinite
+    eigenvalues appear last.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        from gEconpy.model.build import model_from_gcn
+        from gEconpy.model.statistics import eigenvalue_sensitivity
+
+        model = model_from_gcn("rbc.gcn")
+        ds = eigenvalue_sensitivity(model, verbose=False)
+
+        # Filter to finite eigenvalues if desired
+        mod = ds.eigenvalues.sel(component="modulus")
+        finite_mask = (mod > 1e-6) & (mod < 1e6)
+        finite_idx = ds.eigenvalue.values[finite_mask.values]
+        finite = ds.sel(eigenvalue=finite_idx)
+    """
+    if steady_state_kwargs is None:
+        steady_state_kwargs = {}
+
+    param_dict = model.parameters(**parameter_updates)
+    if steady_state is None:
+        steady_state = model.steady_state(**param_dict, verbose=verbose, **steady_state_kwargs)
+
+    jacobians, ss_nodes, param_nodes = model.symbolic_linearization(steady_state=steady_state, verbose=False)
+    A_sym, B_sym, C_sym, D_sym = jacobians
+    param_names = [p.name for p in param_nodes]
+
+    lead_var_idx = model.lead_var_idx
+    eigvals_re_pt, eigvals_im_pt = compute_bk_eigenvalues_pt(A_sym, B_sym, C_sym, D_sym, lead_var_idx)
+    eigvals_re_pt = rewrite_pregrad(eigvals_re_pt)
+    eigvals_im_pt = rewrite_pregrad(eigvals_im_pt)
+
+    n_eig = model.n_variables + model.n_forward
+
+    jac_re = pt.stack(pt.jacobian(eigvals_re_pt, param_nodes), axis=1)
+    jac_im = pt.stack(pt.jacobian(eigvals_im_pt, param_nodes), axis=1)
+
+    ss_values = {k.removesuffix("_ss"): v for k, v in steady_state.items()}
+
+    all_inputs = list(ss_nodes) + list(param_nodes)
+    input_vals = [float(ss_values[v.base_name]) for v in model.variables]
+    input_vals += [float(param_dict[n.name]) for n in param_nodes]
+
+    f = pytensor.function(
+        all_inputs, [eigvals_re_pt, eigvals_im_pt, jac_re, jac_im], on_unused_input="ignore", mode=model._mode
+    )
+    re_vals, im_vals, jac_re_vals, jac_im_vals = f(*input_vals)
+    mod_vals = np.sqrt(re_vals**2 + im_vals**2)
+
+    eigenvalue_coords = np.arange(n_eig)
+    eigenvalues_data = np.stack([re_vals, im_vals, mod_vals], axis=1)
+    gradients_data = np.stack([jac_re_vals, jac_im_vals], axis=1)
+
+    return xr.Dataset(
+        {
+            "eigenvalues": (["eigenvalue", "component"], eigenvalues_data),
+            "gradients": (["eigenvalue", "part", "parameter"], gradients_data),
+        },
+        coords={
+            "eigenvalue": eigenvalue_coords,
+            "component": ["real", "imaginary", "modulus"],
+            "part": ["real", "imaginary"],
+            "parameter": param_names,
+        },
     )

--- a/gEconpy/plotting.py
+++ b/gEconpy/plotting.py
@@ -19,7 +19,7 @@ from xarray_einstats.linalg import diagonal as xr_diagonal
 
 from gEconpy.model.model import Model
 from gEconpy.model.statespace import DSGEStateSpace
-from gEconpy.model.statistics import check_bk_condition
+from gEconpy.model.statistics import check_bk_condition, eigenvalue_sensitivity
 
 
 def set_matplotlib_style():
@@ -714,6 +714,358 @@ def plot_eigenvalues(
     [spine.set_visible(False) for spine in ax.spines.values()]
     ax.grid(ls="--", lw=0.5)
     ax.set_title(f"Eigenvalues of Model Solution\n{n_infinity} Eigenvalues with Infinity Modulus not shown.")
+    return fig
+
+
+def _compute_axis_limits(
+    re_vals: np.ndarray, im_vals: np.ndarray
+) -> tuple[tuple[float, float], tuple[float, float], float]:
+    """
+    Compute axis limits that zoom to eigenvalue data with padding.
+
+    Returns square limits centered on the data for equal aspect ratio plotting.
+
+    Parameters
+    ----------
+    re_vals : ndarray
+        Real parts of eigenvalues.
+    im_vals : ndarray
+        Imaginary parts of eigenvalues.
+
+    Returns
+    -------
+    xlim : tuple of float
+        (xmin, xmax) axis limits.
+    ylim : tuple of float
+        (ymin, ymax) axis limits.
+    half_range : float
+        Half the axis range (for arrow scaling).
+    """
+    if len(re_vals) == 0:
+        return (-1.5, 1.5), (-1.5, 1.5), 1.5
+
+    re_min, re_max = re_vals.min(), re_vals.max()
+    im_min, im_max = im_vals.min(), im_vals.max()
+
+    re_range = max(re_max - re_min, 0.1)
+    im_range = max(im_max - im_min, 0.1)
+    pad_re = re_range * 0.3
+    pad_im = im_range * 0.3
+
+    xlim = (re_min - pad_re, re_max + pad_re)
+    ylim = (im_min - pad_im, im_max + pad_im)
+
+    x_center = (xlim[0] + xlim[1]) / 2
+    y_center = (ylim[0] + ylim[1]) / 2
+    half_range = max(xlim[1] - xlim[0], ylim[1] - ylim[0]) / 2
+
+    xlim = (x_center - half_range, x_center + half_range)
+    ylim = (y_center - half_range, y_center + half_range)
+
+    return xlim, ylim, half_range
+
+
+def _draw_eigenvalue_panel(
+    ax: plt.Axes,
+    re_plot: np.ndarray,
+    im_plot: np.ndarray,
+    mod_plot: np.ndarray,
+    d_re: np.ndarray,
+    d_im: np.ndarray,
+    param_name: str,
+    param_value: float,
+    perturbation: float,
+    xlim: tuple[float, float],
+    ylim: tuple[float, float],
+    plot_circle: bool,
+    show_legend: bool,
+    min_arrow_frac: float,
+) -> None:
+    """
+    Draw a single eigenvalue sensitivity panel.
+
+    Parameters
+    ----------
+    ax : Axes
+        Matplotlib axes to draw on.
+    re_plot : ndarray
+        Real parts of eigenvalues.
+    im_plot : ndarray
+        Imaginary parts of eigenvalues.
+    mod_plot : ndarray
+        Moduli of eigenvalues.
+    d_re : ndarray
+        Gradient of real part w.r.t. parameter.
+    d_im : ndarray
+        Gradient of imaginary part w.r.t. parameter.
+    param_name : str
+        Parameter name for title.
+    param_value : float
+        Current parameter value (for scaling perturbation).
+    perturbation : float
+        Perturbation size as decimal fraction of parameter value (0.01 = 1%).
+    xlim : tuple of float
+        X-axis limits.
+    ylim : tuple of float
+        Y-axis limits.
+    plot_circle : bool
+        Whether to draw the unit circle.
+    show_legend : bool
+        Whether to show legend on this panel.
+    min_arrow_frac : float
+        Minimum gradient magnitude as fraction of max to draw arrow.
+    """
+    if plot_circle:
+        theta = np.linspace(0, 2 * np.pi, 200)
+        ax.plot(np.cos(theta), np.sin(theta), color="k", lw=1, zorder=1, label="Unit circle")
+
+    stable_mask = mod_plot <= 1.0
+    if stable_mask.any():
+        ax.scatter(
+            re_plot[stable_mask],
+            im_plot[stable_mask],
+            c="tab:blue",
+            s=40,
+            lw=0.5,
+            edgecolor="k",
+            zorder=3,
+            label="Stable (|λ|≤1)",
+        )
+    if (~stable_mask).any():
+        ax.scatter(
+            re_plot[~stable_mask],
+            im_plot[~stable_mask],
+            c="tab:red",
+            s=40,
+            lw=0.5,
+            edgecolor="k",
+            zorder=3,
+            label="Unstable (|λ|>1)",
+        )
+
+    # Compute actual eigenvalue displacement for given perturbation
+    # δλ = (∂λ/∂p) * (p * perturbation)
+    delta_p = param_value * perturbation
+    arrow_re = d_re * delta_p
+    arrow_im = d_im * delta_p
+
+    grad_mags = np.sqrt(d_re**2 + d_im**2)
+    max_grad = grad_mags.max() if grad_mags.size > 0 and grad_mags.max() > 1e-12 else 1.0
+    min_grad_threshold = max_grad * min_arrow_frac
+
+    for i in range(len(re_plot)):
+        if grad_mags[i] > min_grad_threshold:
+            ax.annotate(
+                "",
+                xy=(re_plot[i] + arrow_re[i], im_plot[i] + arrow_im[i]),
+                xytext=(re_plot[i], im_plot[i]),
+                arrowprops={"arrowstyle": "->", "color": "k", "lw": 1},
+                zorder=2,
+            )
+
+    ax.set_xlim(xlim)
+    ax.set_ylim(ylim)
+    ax.set_aspect("equal")
+    ax.axhline(0, color="gray", lw=0.5, ls="--", zorder=0)
+    ax.axvline(0, color="gray", lw=0.5, ls="--", zorder=0)
+    ax.set_xlabel("Real")
+    ax.set_ylabel("Imaginary")
+    perturbed_value = param_value * (1 + perturbation)
+    ax.set_title(f"{param_name}: {param_value:.4g} → {perturbed_value:.4g}")
+    for spine in ax.spines.values():
+        spine.set_visible(False)
+    ax.grid(ls="--", lw=0.5, alpha=0.5)
+
+    if show_legend:
+        ax.legend(loc="best", fontsize="small", framealpha=0.9)
+
+
+def _filter_eigenvalues(
+    sensitivity_data: xr.Dataset,
+    filter_zeros: bool,
+    filter_infinite: bool,
+    zero_tol: float,
+    inf_tol: float | None,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, xr.Dataset]:
+    """
+    Filter eigenvalues to exclude zeros and infinites.
+
+    Returns filtered real, imaginary, modulus arrays and the filtered dataset.
+    """
+    re_vals = sensitivity_data.eigenvalues.sel(component="real").values
+    im_vals = sensitivity_data.eigenvalues.sel(component="imaginary").values
+    mod_vals = sensitivity_data.eigenvalues.sel(component="modulus").values
+
+    if inf_tol is None:
+        finite_mods = mod_vals[mod_vals < 1e6]
+        inf_tol = max(10 * finite_mods.max(), 10.0) if len(finite_mods) > 0 else 1e6
+
+    mask = np.ones(len(mod_vals), dtype=bool)
+    if filter_zeros:
+        mask &= mod_vals > zero_tol
+    if filter_infinite:
+        mask &= mod_vals < inf_tol
+
+    valid_indices = sensitivity_data.eigenvalue.values[mask]
+    filtered_data = sensitivity_data.sel(eigenvalue=valid_indices)
+
+    return re_vals[mask], im_vals[mask], mod_vals[mask], filtered_data, len(mod_vals) - mask.sum()
+
+
+def _validate_params_to_plot(
+    params_to_plot: list[str] | None,
+    all_params: list[str],
+) -> list[str]:
+    """Validate and return the list of parameters to plot."""
+    if params_to_plot is None:
+        return all_params
+
+    for p in params_to_plot:
+        if p not in all_params:
+            raise ValueError(f"Parameter '{p}' not found. Available: {all_params}")
+    return params_to_plot
+
+
+def plot_eigenvalue_sensitivity(
+    model: Model,
+    sensitivity_data: xr.Dataset | None = None,
+    params_to_plot: list[str] | None = None,
+    perturbation: float = 0.01,
+    filter_zeros: bool = True,
+    filter_infinite: bool = True,
+    zero_tol: float = 1e-6,
+    inf_tol: float | None = None,
+    min_arrow_frac: float = 0.10,
+    n_cols: int | None = None,
+    figsize: tuple[float, float] | None = None,
+    dpi: int | None = None,
+    plot_circle: bool = True,
+    **eigenvalue_sensitivity_kwargs,
+) -> Figure:
+    """
+    Plot eigenvalue sensitivity to parameters on the complex plane.
+
+    For each parameter, creates a subplot showing eigenvalues on the complex plane with
+    the unit circle. Arrows indicate how each eigenvalue moves when the parameter is
+    increased by the specified fraction.
+
+    Parameters
+    ----------
+    model : Model
+        A gEconpy DSGE model.
+    sensitivity_data : Dataset, optional
+        Pre-computed output from ``eigenvalue_sensitivity``. If not provided, it will be
+        computed using ``eigenvalue_sensitivity_kwargs``.
+    params_to_plot : list of str, optional
+        Parameter names to create plots for. If not provided, all parameters are plotted.
+    perturbation : float, default 0.01
+        Size of parameter perturbation as a decimal fraction (0.01 = 1%, 0.10 = 10%).
+        Arrows show eigenvalue movement for this fractional increase in parameter value.
+    filter_zeros : bool, default True
+        Whether to exclude eigenvalues with modulus below ``zero_tol``.
+    filter_infinite : bool, default True
+        Whether to exclude eigenvalues with modulus above ``inf_tol``.
+    zero_tol : float, default 1e-6
+        Threshold below which eigenvalues are considered zero.
+    inf_tol : float, optional
+        Threshold above which eigenvalues are considered infinite. If not provided,
+        defaults to 10x the maximum finite eigenvalue modulus.
+    min_arrow_frac : float, default 0.10
+        Minimum gradient magnitude as fraction of per-parameter maximum required to
+        draw an arrow. Filters out visually insignificant arrows.
+    n_cols : int, optional
+        Number of columns in the subplot grid. Defaults to ``min(4, n_params)``.
+    figsize : tuple of float, optional
+        Figure size in inches. If not provided, computed from number of subplots.
+    dpi : int, optional
+        Figure resolution. Default is 144.
+    plot_circle : bool, default True
+        Whether to draw the unit circle on each subplot.
+    **eigenvalue_sensitivity_kwargs
+        Keyword arguments passed to ``eigenvalue_sensitivity`` if ``sensitivity_data``
+        is not provided (e.g., ``verbose=False``, parameter overrides).
+
+    Returns
+    -------
+    fig: Figure
+        Matplotlib figure containing the sensitivity plots.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        from gEconpy.model.build import model_from_gcn
+        from gEconpy.plotting import plot_eigenvalue_sensitivity
+
+        model = model_from_gcn("rbc.gcn")
+
+        # Show eigenvalue movement for 1% parameter increase (default)
+        fig = plot_eigenvalue_sensitivity(model, verbose=False)
+
+        # Show eigenvalue movement for 10% parameter increase
+        fig = plot_eigenvalue_sensitivity(model, perturbation=0.10)
+
+        # Plot only specific parameters
+        fig = plot_eigenvalue_sensitivity(model, params_to_plot=["beta", "delta"])
+    """
+    dpi = dpi or 144
+
+    if sensitivity_data is None:
+        sensitivity_data = eigenvalue_sensitivity(model, **eigenvalue_sensitivity_kwargs)
+
+    re_plot, im_plot, mod_plot, filtered_data, n_filtered = _filter_eigenvalues(
+        sensitivity_data, filter_zeros, filter_infinite, zero_tol, inf_tol
+    )
+
+    all_params = list(sensitivity_data.coords["parameter"].values)
+    params_to_plot = _validate_params_to_plot(params_to_plot, all_params)
+
+    n_params = len(params_to_plot)
+    if n_params == 0:
+        raise ValueError("No parameters to plot.")
+
+    n_cols = n_cols or min(4, n_params)
+    figsize = figsize or (4 * n_cols, 4 * ((n_params + n_cols - 1) // n_cols))
+
+    fig = plt.figure(figsize=figsize, dpi=dpi, constrained_layout=True)
+    gs, plot_locs = prepare_gridspec_figure(n_cols, n_params, figure=fig)
+
+    xlim, ylim, _ = _compute_axis_limits(re_plot, im_plot)
+
+    grad_re = filtered_data.gradients.sel(part="real").values
+    grad_im = filtered_data.gradients.sel(part="imaginary").values
+
+    model_param_names = set(model._default_params.keys())
+    param_updates = {k: v for k, v in eigenvalue_sensitivity_kwargs.items() if k in model_param_names}
+    param_dict = model.parameters(**param_updates)
+
+    for idx, param in enumerate(params_to_plot):
+        ax = fig.add_subplot(gs[plot_locs[idx]])
+        param_idx = all_params.index(param)
+        param_value = float(param_dict.get(param, 1.0))
+
+        _draw_eigenvalue_panel(
+            ax=ax,
+            re_plot=re_plot,
+            im_plot=im_plot,
+            mod_plot=mod_plot,
+            d_re=grad_re[:, param_idx],
+            d_im=grad_im[:, param_idx],
+            param_name=param,
+            param_value=param_value,
+            perturbation=perturbation,
+            xlim=xlim,
+            ylim=ylim,
+            plot_circle=plot_circle,
+            show_legend=(idx == 0),
+            min_arrow_frac=min_arrow_frac,
+        )
+
+    title_parts = [f"Eigenvalue Sensitivity ({perturbation:.1%} perturbation)"]
+    if n_filtered > 0:
+        title_parts.append(f"{n_filtered} zero/infinite eigenvalues not shown")
+    fig.suptitle("\n".join(title_parts))
+
     return fig
 
 

--- a/gEconpy/pytensorf/__init__.py
+++ b/gEconpy/pytensorf/__init__.py
@@ -1,3 +1,4 @@
+from gEconpy.pytensorf import real  # noqa: F401
 from gEconpy.pytensorf.compile import clear_compile_cache, compile_cache_info, compile_pytensor_function
 from gEconpy.pytensorf.real_eig import real_eig
 from gEconpy.pytensorf.sparse_jacobian import sparse_jacobian

--- a/gEconpy/pytensorf/__init__.py
+++ b/gEconpy/pytensorf/__init__.py
@@ -1,9 +1,11 @@
 from gEconpy.pytensorf.compile import clear_compile_cache, compile_cache_info, compile_pytensor_function
+from gEconpy.pytensorf.real_eig import real_eig
 from gEconpy.pytensorf.sparse_jacobian import sparse_jacobian
 
 __all__ = [
     "clear_compile_cache",
     "compile_cache_info",
     "compile_pytensor_function",
+    "real_eig",
     "sparse_jacobian",
 ]

--- a/gEconpy/pytensorf/real.py
+++ b/gEconpy/pytensorf/real.py
@@ -1,0 +1,17 @@
+"""JAX dispatch for the pytensor scalar Real Op."""
+
+try:
+    import jax.numpy as jnp
+
+    from pytensor.link.jax.dispatch import jax_funcify
+    from pytensor.scalar import Real
+
+    @jax_funcify.register(Real)
+    def jax_funcify_Real(op, node, **kwargs):  # noqa: ARG001
+        def real_jax(x):
+            return jnp.real(x)
+
+        return real_jax
+
+except ImportError:
+    pass

--- a/gEconpy/pytensorf/real_eig.py
+++ b/gEconpy/pytensorf/real_eig.py
@@ -4,6 +4,7 @@ import pytensor.tensor as pt
 from pytensor.gradient import DisconnectedType
 from pytensor.graph.basic import Apply
 from pytensor.graph.op import Op
+from pytensor.tensor.blockwise import Blockwise
 
 
 class RealEig(Op):
@@ -17,6 +18,7 @@ class RealEig(Op):
     """
 
     __props__ = ()
+    gufunc_signature = "(m,m)->(m),(m)"
 
     def make_node(self, M):
         M = pt.as_tensor_variable(M)
@@ -60,9 +62,6 @@ class RealEig(Op):
         return [M_bar.real]
 
 
-_real_eig = RealEig()
-
-
 def real_eig(M):
     r"""Compute eigenvalues of a real matrix, returning real and imaginary parts separately.
 
@@ -95,7 +94,7 @@ def real_eig(M):
         grad_re = pt.grad(re.sum(), M)
     """
     M = pt.as_tensor_variable(M)
-    return _real_eig(M)
+    return Blockwise(RealEig())(M)
 
 
 try:

--- a/gEconpy/pytensorf/real_eig.py
+++ b/gEconpy/pytensorf/real_eig.py
@@ -1,0 +1,141 @@
+import numpy as np
+import pytensor.tensor as pt
+
+from pytensor.gradient import DisconnectedType
+from pytensor.graph.basic import Apply
+from pytensor.graph.op import Op
+
+
+class RealEig(Op):
+    """Eigenvalue decomposition returning real and imaginary parts as separate real tensors.
+
+    Wraps ``numpy.linalg.eig``, splits the result into two real-valued outputs, and
+    sorts by ascending modulus.  The VJP uses the standard eigenvalue perturbation
+    formula (arXiv:1701.00392 eq 4.77):
+    ``M_bar = Re(V^{-T} diag(g_alpha - i * g_beta) V^T)``.
+    Only first-order derivatives are supported (see jax-ml/jax#2748).
+    """
+
+    __props__ = ()
+
+    def make_node(self, M):
+        M = pt.as_tensor_variable(M)
+        out_shape = M.type.shape[0]
+        if M.ndim != 2:
+            raise ValueError(f"RealEig requires a 2-d matrix, got ndim={M.ndim}")
+        outputs = [pt.vector(dtype=M.dtype, shape=(out_shape,)), pt.vector(dtype=M.dtype, shape=(out_shape,))]
+        return Apply(self, [M], outputs)
+
+    def perform(self, _node, inputs, outputs):
+        (M,) = inputs
+        eigvals = np.linalg.eig(M)[0]
+        idx = np.argsort(np.abs(eigvals))
+        eigvals = eigvals[idx]
+        outputs[0][0] = np.real(eigvals).astype(M.dtype)
+        outputs[1][0] = np.imag(eigvals).astype(M.dtype)
+
+    def L_op(self, inputs, outputs, output_grads):
+        (M,) = inputs
+        g_real, g_imag = output_grads
+
+        if isinstance(g_real.type, DisconnectedType):
+            g_real = pt.zeros_like(outputs[0])
+        if isinstance(g_imag.type, DisconnectedType):
+            g_imag = pt.zeros_like(outputs[1])
+
+        # Recompute eigenvectors — same strategy as JAX's eigvals VJP.
+        _eigvals, V = pt.linalg.eig(M)
+
+        # Sort to match our modulus-ascending ordering in perform.
+        sort_idx = pt.argsort(pt.abs(_eigvals))
+        V = V[:, sort_idx]
+
+        # Complex gradient vector: g = g_bar_real - i * g_bar_imag
+        g = g_real.astype("complex128") - 1j * g_imag.astype("complex128")
+
+        # VJP: M̄ = Re(V⁻ᵀ diag(g) Vᵀ)
+        V_inv = pt.linalg.solve(V, pt.eye(M.shape[0], dtype="complex128"))
+        M_bar = V_inv.T @ pt.diag(g) @ V.T
+
+        return [M_bar.real]
+
+
+_real_eig = RealEig()
+
+
+def real_eig(M):
+    r"""Compute eigenvalues of a real matrix, returning real and imaginary parts separately.
+
+    Unlike ``pt.linalg.eig``, the outputs are real-valued tensors, so reverse-mode
+    differentiation through both components works out of the box.  Eigenvalues are
+    sorted by ascending modulus.
+
+    Parameters
+    ----------
+    M : array_like or TensorVariable
+        A real-valued square matrix of shape ``(n, n)``.
+
+    Returns
+    -------
+    eigvals_real : TensorVariable
+        Real parts of the eigenvalues, shape ``(n,)``.
+    eigvals_imag : TensorVariable
+        Imaginary parts of the eigenvalues, shape ``(n,)``.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        import pytensor.tensor as pt
+        from gEconpy.pytensorf.real_eig import real_eig
+
+        M = pt.dmatrix("M")
+        re, im = real_eig(M)
+        modulus = pt.sqrt(re**2 + im**2)
+        grad_re = pt.grad(re.sum(), M)
+    """
+    M = pt.as_tensor_variable(M)
+    return _real_eig(M)
+
+
+try:
+    import jax.numpy as jnp
+
+    from pytensor.link.jax.dispatch.basic import jax_funcify
+
+    @jax_funcify.register(RealEig)
+    def jax_funcify_RealEig(_op, **_kwargs):
+        def real_eig_jax(M):
+            eigvals = jnp.linalg.eigvals(M)
+            idx = jnp.argsort(jnp.abs(eigvals))
+            eigvals = eigvals[idx]
+            return eigvals.real, eigvals.imag
+
+        return real_eig_jax
+
+
+except ImportError:
+    pass
+
+
+try:
+    from pytensor.link.numba.dispatch.basic import (
+        numba_njit,
+        register_funcify_default_op_cache_key,
+    )
+
+    @register_funcify_default_op_cache_key(RealEig)
+    def numba_funcify_RealEig(_op, _node, **_kwargs):
+        @numba_njit
+        def real_eig_numba(M):
+            M_c = M.astype(np.complex128)
+            eigvals = np.linalg.eig(M_c)[0]
+            idx = np.argsort(np.abs(eigvals))
+            eigvals = eigvals[idx]
+            return np.real(eigvals).astype(M.dtype), np.imag(eigvals).astype(M.dtype)
+
+        cache_version = 1
+        return real_eig_numba, cache_version
+
+except ImportError:
+    pass

--- a/gEconpy/pytensorf/real_eig.py
+++ b/gEconpy/pytensorf/real_eig.py
@@ -104,7 +104,7 @@ try:
     from pytensor.link.jax.dispatch.basic import jax_funcify
 
     @jax_funcify.register(RealEig)
-    def jax_funcify_RealEig(_op, **_kwargs):
+    def jax_funcify_RealEig(op, node, **kwargs):  # noqa: ARG001
         def real_eig_jax(M):
             eigvals = jnp.linalg.eigvals(M)
             idx = jnp.argsort(jnp.abs(eigvals))
@@ -125,7 +125,7 @@ try:
     )
 
     @register_funcify_default_op_cache_key(RealEig)
-    def numba_funcify_RealEig(_op, _node, **_kwargs):
+    def numba_funcify_RealEig(op, node, **kwargs):  # noqa: ARG001
         @numba_njit
         def real_eig_numba(M):
             M_c = M.astype(np.complex128)

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -19,6 +19,8 @@ from gEconpy.model.build import model_from_gcn
 from gEconpy.model.compile import compile_for_scipy, make_cache_key
 from gEconpy.model.perturbation import (
     check_bk_condition,
+    compute_bk_eigenvalues,
+    compute_bk_eigenvalues_pt,
 )
 from gEconpy.model.simulate import impulse_response_function, simulate
 from gEconpy.model.statistics import (
@@ -408,6 +410,36 @@ def test_linearize_with_custom_params(rng):
     assert A[technology_eq_idx, A_idx] == rho
 
 
+@pytest.mark.parametrize(
+    "gcn_file",
+    [
+        "one_block_1_ss.gcn",
+        "rbc_2_block_ss.gcn",
+        pytest.param("full_nk.gcn", marks=pytest.mark.include_nk),
+    ],
+    ids=["one_block_ss", "two_block_ss", "full_nk"],
+)
+def test_symbolic_linearization_returns_pytensor_graphs(gcn_file):
+    model = load_and_cache_model(gcn_file)
+    jacobians, ss_nodes, param_nodes = model.symbolic_linearization(verbose=False)
+
+    assert len(jacobians) == 4
+    assert all(isinstance(j, pt.TensorVariable) for j in jacobians)
+    assert len(ss_nodes) == len(model.variables)
+    assert all(isinstance(n, pt.TensorVariable) for n in ss_nodes)
+    assert all(isinstance(n, pt.TensorVariable) for n in param_nodes)
+
+
+def test_symbolic_linearization_caches():
+    model = load_and_cache_model("one_block_1_ss.gcn")
+    jac1, _ss1, _p1 = model.symbolic_linearization(verbose=False)
+    jac2, _ss2, _p2 = model.symbolic_linearization(verbose=False)
+
+    # Same objects on cache hit
+    for a, b in zip(jac1, jac2, strict=False):
+        assert a is b
+
+
 def test_invalid_solver_raises():
     file_path = "tests/_resources/test_gcns/one_block_1_ss.gcn"
     model = model_from_gcn(file_path, verbose=False)
@@ -542,6 +574,50 @@ def test_check_bk_condition():
 
     bk_res = check_bk_condition(A, B, C, D, return_value="bool", verbose=False)
     assert bk_res
+
+
+def test_compute_bk_eigenvalues():
+    file_path = "tests/_resources/test_gcns/rbc_linearized.gcn"
+    model = model_from_gcn(file_path, verbose=False, on_unused_parameters="ignore")
+    A, B, C, D = model.linearize_model()
+
+    eigvals_real, eigvals_imag, n_forward = compute_bk_eigenvalues(A, B, C, D)
+
+    modulus = np.sqrt(eigvals_real**2 + eigvals_imag**2)
+    n_unstable = (modulus > 1).sum()
+
+    assert n_forward > 0
+    assert n_forward == n_unstable
+
+    # Moduli should be sorted ascending
+    assert np.all(np.diff(modulus) >= -1e-12)
+
+
+def test_compute_bk_eigenvalues_pt():
+    file_path = "tests/_resources/test_gcns/rbc_linearized.gcn"
+    model = model_from_gcn(file_path, verbose=False, on_unused_parameters="ignore")
+    A_np, B_np, C_np, D_np = model.linearize_model()
+
+    eigvals_real_np, eigvals_imag_np, _n_forward = compute_bk_eigenvalues(A_np, B_np, C_np, D_np)
+
+    # Derive lead_var_idx from C the same way _find_lead_variables does
+    lead_var_idx = np.where(np.abs(C_np).sum(axis=0) > 1e-8)[0]
+
+    A_pt = pt.as_tensor_variable(A_np)
+    B_pt = pt.as_tensor_variable(B_np)
+    C_pt = pt.as_tensor_variable(C_np)
+    D_pt = pt.as_tensor_variable(D_np)
+
+    re_pt, im_pt = compute_bk_eigenvalues_pt(A_pt, B_pt, C_pt, D_pt, lead_var_idx)
+    re_val, im_val = re_pt.eval(), im_pt.eval()
+
+    # Moduli must agree between numpy (QZ) and pytensor (eig) versions
+    modulus_np = np.sqrt(eigvals_real_np**2 + eigvals_imag_np**2)
+    modulus_pt = np.sqrt(re_val**2 + im_val**2)
+
+    # The two methods (ordqz vs solve+eig) may differ in which eigenvalues they compute,
+    # but the count of unstable eigenvalues (modulus > 1) must agree.
+    assert (modulus_np > 1).sum() == (modulus_pt > 1).sum()
 
 
 def test_summarize_perturbation_solution():

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -26,6 +26,7 @@ from gEconpy.model.simulate import impulse_response_function, simulate
 from gEconpy.model.statistics import (
     autocorrelation_matrix,
     build_Q_matrix,
+    eigenvalue_sensitivity,
     matrix_to_dataframe,
     stationary_covariance_matrix,
     summarize_perturbation_solution,
@@ -618,6 +619,30 @@ def test_compute_bk_eigenvalues_pt():
     # The two methods (ordqz vs solve+eig) may differ in which eigenvalues they compute,
     # but the count of unstable eigenvalues (modulus > 1) must agree.
     assert (modulus_np > 1).sum() == (modulus_pt > 1).sum()
+
+
+def test_eigenvalue_sensitivity():
+    """Verify eigenvalue_sensitivity returns eigenvalues consistent with compute_bk_eigenvalues."""
+    model = load_and_cache_model("basic_rbc.gcn")
+    A, B, C, D = model.linearize_model(verbose=False)
+
+    # Get eigenvalues from numpy reference
+    re_np, im_np, _ = compute_bk_eigenvalues(A, B, C, D)
+    mod_np = np.sqrt(re_np**2 + im_np**2)
+
+    # Get eigenvalues from sensitivity function
+    ds = eigenvalue_sensitivity(model, verbose=False)
+    mod_pt = ds.eigenvalues.sel(component="modulus").values
+
+    # Filter to finite eigenvalues and compare
+    finite_np = mod_np[(mod_np > 1e-6) & (mod_np < 1e6)]
+    finite_pt = mod_pt[(mod_pt > 1e-6) & (mod_pt < 1e6)]
+
+    assert_allclose(np.sort(finite_np), np.sort(finite_pt), rtol=1e-6)
+
+    # Gradients should be non-trivial for at least some eigenvalue/parameter pairs
+    grad_mags = np.sqrt(ds.gradients.sel(part="real").values ** 2 + ds.gradients.sel(part="imaginary").values ** 2)
+    assert grad_mags.max() > 1e-10
 
 
 def test_summarize_perturbation_solution():

--- a/tests/pytensorf/test_real_eig.py
+++ b/tests/pytensorf/test_real_eig.py
@@ -1,0 +1,86 @@
+import numpy as np
+import pytensor
+import pytensor.tensor as pt
+import pytest
+
+from numpy.testing import assert_allclose
+from pytensor.gradient import verify_grad
+
+from gEconpy.pytensorf.real_eig import RealEig, real_eig
+
+
+@pytest.fixture
+def rng():
+    return np.random.default_rng()
+
+
+@pytest.fixture
+def test_matrix(rng):
+    return rng.standard_normal((4, 4))
+
+
+class TestRealEig:
+    def test_output_static_shapes(self):
+        M = pt.dmatrix("M", shape=(4, 4))
+        re, im = real_eig(M)
+        assert re.type.shape == (4,)
+        assert im.type.shape == (4,)
+
+    def test_matches_numpy_eig(self, test_matrix):
+        M = pt.dmatrix("M")
+        re, im = real_eig(M)
+        f = pytensor.function([M], [re, im])
+        r, i = f(test_matrix)
+
+        np_eigvals = np.linalg.eig(test_matrix)[0]
+        np_eigvals = np_eigvals[np.argsort(np.abs(np_eigvals))]
+
+        # Moduli must match exactly
+        assert_allclose(np.sqrt(r**2 + i**2), np.abs(np_eigvals))
+        # Real parts match (conjugate pairs have equal real parts)
+        assert_allclose(r, np.real(np_eigvals))
+        # Imaginary parts match up to sign within conjugate pairs
+        assert_allclose(np.abs(i), np.abs(np.imag(np_eigvals)))
+
+    @pytest.mark.parametrize("case", ["real", "imag", "combined"], ids=str)
+    def test_grad(self, test_matrix, rng, case):
+        def f(M):
+            re, im = real_eig(M)
+            if case == "real":
+                return re.sum()
+            if case == "imag":
+                return im.sum()
+            # case == 'combined'
+            return (re + im).sum()
+
+        verify_grad(f, [test_matrix], rng=rng)
+
+    def test_numba_dispatch(self, test_matrix):
+        """Numba dispatch produces the same moduli; conjugate pair ordering may differ."""
+        M = pt.dmatrix("M")
+        re, im = real_eig(M)
+
+        f_py = pytensor.function([M], [re, im])
+        f_numba = pytensor.function([M], [re, im], mode="NUMBA")
+
+        r_py, i_py = f_py(test_matrix)
+        r_nb, i_nb = f_numba(test_matrix)
+
+        mod_py = np.sqrt(r_py**2 + i_py**2)
+        mod_nb = np.sqrt(r_nb**2 + i_nb**2)
+        assert_allclose(mod_nb, mod_py)
+
+    def test_jax_dispatch(self, test_matrix):
+        """JAX dispatch produces the same moduli; conjugate pair ordering may differ."""
+        M = pt.dmatrix("M")
+        re, im = real_eig(M)
+
+        f_py = pytensor.function([M], [re, im])
+        f_jax = pytensor.function([M], [re, im], mode="JAX")
+
+        r_py, i_py = f_py(test_matrix)
+        r_jax, i_jax = f_jax(test_matrix)
+
+        mod_py = np.sqrt(r_py**2 + i_py**2)
+        mod_jax = np.sqrt(r_jax**2 + i_jax**2)
+        assert_allclose(mod_jax, mod_py)


### PR DESCRIPTION
- Add a public method to get back symbolic linearized system
- Add RealEig Op to compute differentiable eigenvalues
- Add support for fully symbolic bk_conditions
- Clean up bk code
- Add eigenvalue_sensitivity and plot_eigenvalue_sensitivity to study gradients of eigenvalues w.r.t parameters

<!-- readthedocs-preview gEconpy start -->
----
📚 Documentation preview 📚: https://gEconpy--83.org.readthedocs.build/en/83/

<!-- readthedocs-preview gEconpy end -->