### PR TITLE
Allow constant parameters in `data_from_prior`

### DIFF
--- a/gEconpy/model/simulate.py
+++ b/gEconpy/model/simulate.py
@@ -176,8 +176,9 @@ def _simulate_linear_system(T: np.ndarray, R: np.ndarray, shock_traj: np.ndarray
     n_vars = T.shape[0]
 
     out = np.zeros((T_len, n_vars), dtype=float)
+    out[0] = R @ shock_traj[0]
     for t in range(1, T_len):
-        out[t] = T @ out[t - 1] + R @ shock_traj[t - 1]
+        out[t] = T @ out[t - 1] + R @ shock_traj[t]
     return out
 
 
@@ -394,8 +395,9 @@ def simulate(
     data = np.zeros((n_simulations, simulation_length, len(model.variables)))
     T, R = _maybe_solve_model(model, T, R, **solve_model_kwargs)
 
+    data[:, 0, :] = np.einsum("nk,sk->sn", R, epsilons[:, 0, :])
     for t in range(1, simulation_length):
-        stochastic = np.einsum("nk,sk->sn", R, epsilons[:, t - 1, :])
+        stochastic = np.einsum("nk,sk->sn", R, epsilons[:, t, :])
         deterministic = np.einsum("nm,sm->sn", T, data[:, t - 1, :])
         data[:, t, :] = deterministic + stochastic
 

--- a/gEconpy/model/statespace.py
+++ b/gEconpy/model/statespace.py
@@ -374,9 +374,10 @@ class DSGEStateSpace(PyMCStateSpace):
         )
 
         for variable in self.input_parameters:
-            self._tensor_variable_info = self._tensor_variable_info.add(
-                SymbolicVariable(name=variable.name, symbolic_variable=variable)
-            )
+            if variable.name not in constant_params:
+                self._tensor_variable_info = self._tensor_variable_info.add(
+                    SymbolicVariable(name=variable.name, symbolic_variable=variable)
+                )
 
     def set_states(self) -> tuple[State, ...]:
         observed_states = self._obs_state_names if self._obs_state_names is not None else []
@@ -442,7 +443,6 @@ class DSGEStateSpace(PyMCStateSpace):
             missing_fill_value=missing_fill_value,
             cov_jitter=cov_jitter,
             save_kalman_filter_outputs_in_idata=save_kalman_filter_outputs_in_idata,
-            mode=self._mode,
         )
 
         pymc_model = pm.modelcontext(None)
@@ -514,14 +514,17 @@ class DSGEStateSpace(PyMCStateSpace):
         if exclude_priors is None:
             exclude_priors = []
 
+        constant_params = self.constant_parameters if self.constant_parameters is not None else []
+        skip = set(exclude_priors) | set(constant_params)
+
         with pm.modelcontext(None):
             for prior, dist in self.param_priors.items():
-                if prior in exclude_priors:
+                if prior in skip:
                     continue
                 dist.to_pymc(name=prior)
 
             for prior, dist in self.shock_priors.items():
-                if prior in exclude_priors:
+                if prior in skip:
                     continue
                 dist.to_pymc()
 
@@ -588,7 +591,9 @@ def data_from_prior(
             pm.set_data({"data": dummy_data.fillna(-9999)})
 
     with warnings.catch_warnings(action="ignore"), freeze_dims_and_data(new_model):
-        prior_idata = pm.sample_prior_predictive(n_samples, compile_kwargs={"mode": "JAX"}, random_seed=rng)
+        prior_idata = pm.sample_prior_predictive(
+            n_samples, compile_kwargs={"mode": statepace_mod._mode}, random_seed=rng
+        )
 
     with warnings.catch_warnings(action="ignore"):
         prior_trajectories = statepace_mod.sample_unconditional_prior(prior_idata, random_seed=rng)

--- a/gEconpy/model/statespace.py
+++ b/gEconpy/model/statespace.py
@@ -279,7 +279,7 @@ class DSGEStateSpace(PyMCStateSpace):
         self,
         observed_states: list[str],
         measurement_error: list[str] | None = None,
-        constant_params: list[str] | None = None,
+        constant_params: list[str] | Literal["auto"] | None = None,
         full_shock_covaraince: bool = False,
         solver: SolverType = "gensys",
         mode: str | None = None,
@@ -311,6 +311,9 @@ class DSGEStateSpace(PyMCStateSpace):
         # Validate constant params
         if constant_params is None:
             constant_params = []
+        elif constant_params == "auto":
+            param_prior_names = set(self.param_priors.keys())
+            constant_params = [x.name for x in self.input_parameters if x.name not in param_prior_names]
         else:
             input_param_names = [x.name for x in self.input_parameters]
             unknown_params = [x for x in constant_params if x not in input_param_names]

--- a/gEconpy/model/statespace.py
+++ b/gEconpy/model/statespace.py
@@ -539,6 +539,8 @@ def data_from_prior(
     n_samples: int = 500,
     pct_missing: float = 0,
     random_seed: np.random.Generator | int | None = None,
+    mvn_method: str = "svd",
+    build_statespace_kwargs: dict | None = None,
 ) -> tuple[xr.Dataset, pd.DataFrame, az.InferenceData]:
     """
     Generate artificial data from prior predictive samples.
@@ -561,6 +563,11 @@ def data_from_prior(
         Percentage of missing data to introduce into the generated data. Must be between 0 and 1.
     random_seed: np.random.Generator or int, optional
         Random number generator to use for sampling. If None, the default numpy random number generator is used.
+    mvn_method : str, optional
+        Method to use for sampling from the multivariate normal distribution of the state transitions. Passed to
+        sample_unconditional_posterior.
+    build_statespace_kwargs : dict, optional
+        Additional keyword arguments passed to DSGEStateSpace.build_statespace_graph
 
     Returns
     -------
@@ -572,6 +579,17 @@ def data_from_prior(
         Draws from the prior predictive distribution, plus conditional prior predictive samples.
     """
     rng = np.random.default_rng(random_seed)
+    default_statespace_kwargs = {
+        "add_bk_check": False,
+        "add_solver_success_check": True,
+        "add_norm_check": True,
+        "add_steady_state_penalty": True,
+    }
+
+    if build_statespace_kwargs is None:
+        build_statespace_kwargs = {}
+
+    default_statespace_kwargs.copy().update(build_statespace_kwargs)
 
     if index is None:
         index = pd.date_range(start="1980-01-01", end="2024-11-01", freq="QS-OCT")
@@ -583,13 +601,7 @@ def data_from_prior(
 
     with new_model:
         if "data" not in new_model:
-            statepace_mod.build_statespace_graph(
-                dummy_data,
-                add_bk_check=False,
-                add_solver_success_check=True,
-                add_norm_check=True,
-                add_steady_state_penalty=True,
-            )
+            statepace_mod.build_statespace_graph(dummy_data, **build_statespace_kwargs)
         else:
             pm.set_data({"data": dummy_data.fillna(-9999)})
 
@@ -599,7 +611,9 @@ def data_from_prior(
         )
 
     with warnings.catch_warnings(action="ignore"):
-        prior_trajectories = statepace_mod.sample_unconditional_prior(prior_idata, random_seed=rng)
+        prior_trajectories = statepace_mod.sample_unconditional_prior(
+            prior_idata, random_seed=rng, mvn_method=mvn_method
+        )
 
     prior_idata["unconditional_prior"] = prior_trajectories
 

--- a/tests/model/perfect_foresight/test_solve.py
+++ b/tests/model/perfect_foresight/test_solve.py
@@ -83,13 +83,13 @@ class TestBackwardOnlyModel:
         irf = (
             impulse_response_function(
                 backward_var_model,
-                simulation_length=1 + simulation_length,
+                simulation_length=simulation_length,
                 shock_size={"epsilon_x": 0.1},
             )
             .isel(shock=0)
             .to_pandas()
         )
-        assert_allclose(trajectory["x"].values, irf["x"].values[1:])
+        assert_allclose(trajectory["x"].values, irf["x"].values)
 
 
 class TestForwardOnlyModel:
@@ -156,7 +156,7 @@ class TestForwardOnlyModel:
         irf = (
             impulse_response_function(
                 forward_model,
-                simulation_length=1 + simulation_length,
+                simulation_length=simulation_length,
                 shock_size={"epsilon_rn": 0.01},
             )
             .isel(shock=0)
@@ -164,7 +164,7 @@ class TestForwardOnlyModel:
         )
         assert_allclose(
             trajectory[["x", "pi", "i", "rn"]].values,
-            irf[["x", "pi", "i", "rn"]].iloc[1:].values,
+            irf[["x", "pi", "i", "rn"]].values,
             atol=1e-8,
             rtol=1e-8,
         )

--- a/tests/model/test_statespace.py
+++ b/tests/model/test_statespace.py
@@ -1,9 +1,13 @@
+import warnings
+
 import numpy as np
 import pandas as pd
 import pymc as pm
 import pytensor
 import pytest
 
+from gEconpy import statespace_from_gcn
+from gEconpy.model.statespace import data_from_prior
 from tests._resources.cache_compiled_models import (
     load_and_cache_model,
     load_and_cache_statespace,
@@ -98,3 +102,33 @@ def test_backward_direct_statespace_logp():
         point = m.initial_point()
         logp = m.compile_logp()(point)
         assert np.isfinite(logp)
+
+
+@pytest.mark.filterwarnings("ignore:Provided data contains missing values and will be automatically imputed")
+def test_data_from_prior_with_constant_params():
+    ss_mod = statespace_from_gcn("tests/_resources/test_gcns/rbc_linearized.gcn", verbose=False)
+    ss_mod.configure(
+        observed_states=["Y", "C", "L"],
+        measurement_error=["Y", "C", "L"],
+        constant_params=["beta", "delta"],
+        solver="scan_cycle_reduction",
+        mode="JAX",
+        verbose=False,
+    )
+
+    with pm.Model(coords=ss_mod.coords) as pm_mod:
+        ss_mod.to_pymc()
+        pm.Gamma("sigma_epsilon_A", alpha=2, beta=100)
+        for var_name in ss_mod.observed_states:
+            pm.Gamma(f"error_sigma_{var_name}", alpha=2, beta=100)
+
+    true_params, data, _prior_idata = data_from_prior(
+        ss_mod,
+        pm_mod,
+        n_samples=5,
+        random_seed=42,
+    )
+
+    assert data.shape[1] == 3
+    assert "beta" not in true_params.data_vars
+    assert "delta" not in true_params.data_vars

--- a/tests/model/test_statespace.py
+++ b/tests/model/test_statespace.py
@@ -132,3 +132,28 @@ def test_data_from_prior_with_constant_params():
     assert data.shape[1] == 3
     assert "beta" not in true_params.data_vars
     assert "delta" not in true_params.data_vars
+
+
+def test_constant_params_auto():
+    ss_mod = statespace_from_gcn("tests/_resources/test_gcns/open_rbc.gcn", verbose=False)
+    ss_mod.configure(
+        observed_states=["Y"],
+        constant_params="auto",
+        solver="scan_cycle_reduction",
+        verbose=False,
+    )
+
+    params_with_priors = set(ss_mod.param_priors.keys())
+    input_param_names = {x.name for x in ss_mod.input_parameters}
+    expected_constant = input_param_names - params_with_priors
+
+    assert len(expected_constant) > 0, "Test requires a model with some prior-less parameters"
+    assert set(ss_mod.constant_parameters) == expected_constant
+
+    # Constant params should not appear in param_names
+    for name in expected_constant:
+        assert name not in ss_mod.param_names
+
+    # Params with priors should still be free
+    for name in params_with_priors:
+        assert name in ss_mod.param_names

--- a/tests/solvers/test_backward_looking.py
+++ b/tests/solvers/test_backward_looking.py
@@ -71,10 +71,10 @@ class TestBackwardLookingIRF:
 
         irf = impulse_response_function(model, T, R, simulation_length=n_steps, shock_size=1.0)
 
-        # Convention: t=0 is pre-shock, impact lands at t=1
+        # Convention: impact lands at t=0
         expected = np.zeros((n_steps, n_vars))
-        expected[1] = R.squeeze()
-        for t in range(2, n_steps):
+        expected[0] = R.squeeze()
+        for t in range(1, n_steps):
             expected[t] = T @ expected[t - 1]
 
         assert_allclose(irf.values.squeeze(), expected, atol=1e-10)


### PR DESCRIPTION
`data_from_prior` was previously failing when a model had constant_params, because it was trying to insert variables that no longer existed.

`to_pymc()` also now respects constant_params by filtering out parameters marked constant

I also shifted IRF output so the shock lands at t=0, matching dynare and making comparison with PF easier.

<!-- readthedocs-preview gEconpy start -->
----
📚 Documentation preview 📚: https://gEconpy--85.org.readthedocs.build/en/85/

<!-- readthedocs-preview gEconpy end -->