### PR TITLE
Allow mix-frequency observations

### DIFF
--- a/gEconpy/__init__.py
+++ b/gEconpy/__init__.py
@@ -15,7 +15,7 @@ from gEconpy.dynare_convert import make_mod_file
 from gEconpy.model.build import model_from_gcn, statespace_from_gcn
 from gEconpy.model.perfect_foresight.solve import solve_perfect_foresight
 from gEconpy.model.simulate import impulse_response_function, simulate
-from gEconpy.model.statespace import data_from_prior
+from gEconpy.model.statespace import data_from_prior, prepare_mixed_frequency_data
 from gEconpy.model.statistics import (
     autocorrelation_matrix,
     autocovariance_matrix,
@@ -57,6 +57,7 @@ __all__ = [
     "model_from_gcn",
     "parser",
     "plotting",
+    "prepare_mixed_frequency_data",
     "print_gcn_file",
     "print_steady_state",
     "simulate",

--- a/gEconpy/model/model.py
+++ b/gEconpy/model/model.py
@@ -304,7 +304,7 @@ class Model:
     def f_params(self) -> Callable:
         """Compiled function mapping free parameter values to the full parameter dictionary."""
         if self._f_params is None:
-            f, _cache = compile_param_dict_func(self._param_dict, self._deterministic_dict)
+            f, _cache = compile_param_dict_func(self._param_dict, self._deterministic_dict, mode=self._mode)
             self._f_params = f
         return self._f_params
 
@@ -315,12 +315,13 @@ class Model:
             if not self._ss_solution_dict:
                 return None
 
-            _, cache = compile_param_dict_func(self._param_dict, self._deterministic_dict)
+            _, cache = compile_param_dict_func(self._param_dict, self._deterministic_dict, mode=self._mode)
             all_params = list(self._param_dict.to_sympy().keys()) + list(self._deterministic_dict.to_sympy().keys())
             f_ss, _cache = compile_known_ss(
                 self._ss_solution_dict,
                 self._variables,
                 all_params,
+                mode=self._mode,
                 cache=cache,
             )
             self._f_ss = f_ss
@@ -1361,7 +1362,7 @@ class Model:
 
         if cache_key not in self._linearize_cache:
             all_inputs = list(ss_input_nodes) + list(param_input_nodes)
-            f = compile_pytensor_function(all_inputs, jacobians, on_unused_input="ignore")
+            f = compile_pytensor_function(all_inputs, jacobians, mode=self._mode, on_unused_input="ignore")
             self._linearize_cache[cache_key] = f
         else:
             f = self._linearize_cache[cache_key]

--- a/gEconpy/model/parameters.py
+++ b/gEconpy/model/parameters.py
@@ -13,6 +13,7 @@ def compile_param_dict_func(
     deterministic_dict: SymbolDictionary,
     cache: dict | None = None,
     return_symbolic: bool = False,
+    mode: str | None = None,
 ) -> tuple[Callable, dict]:
     """
     Compile a function to compute model parameters from given "free" parameters.
@@ -34,6 +35,9 @@ def compile_param_dict_func(
     return_symbolic: bool, default False
         When true, return a symbolic graph representing the computation of parameter values
         rather than a compiled pytensor function.
+    mode : str or None, optional
+        Pytensor compilation mode (e.g. ``'JAX'``, ``'FAST_COMPILE'``).
+        Forwarded to the underlying compiler. Default is None.
 
     Returns
     -------
@@ -56,6 +60,7 @@ def compile_param_dict_func(
         return_symbolic=return_symbolic,
         pop_return=False,
         stack_return=not return_symbolic,
+        mode=mode,
     )
 
     if return_symbolic:

--- a/gEconpy/model/statespace.py
+++ b/gEconpy/model/statespace.py
@@ -1,7 +1,7 @@
 import logging
 import warnings
 
-from typing import Literal, get_args
+from typing import Literal
 
 import arviz as az
 import numpy as np
@@ -35,10 +35,9 @@ from gEconpy.solvers.gensys import gensys_pt
 _log = logging.getLogger(__name__)
 floatX = pytensor.config.floatX
 
-SolverType = Literal["gensys", "cycle_reduction", "scan_cycle_reduction", "backward_direct"]
-valid_solvers = get_args(SolverType)
-
-FlowAggregation = Literal["sum", "average"]
+VALID_SOLVERS = ("gensys", "cycle_reduction", "scan_cycle_reduction", "backward_direct")
+VALID_AGGREGATIONS = ("sum", "mean", "first", "last")
+CUMULATOR_AGGREGATIONS = ("sum", "mean")
 
 
 class DSGEStateSpace(PyMCStateSpace):
@@ -145,9 +144,8 @@ class DSGEStateSpace(PyMCStateSpace):
         self._lead_var_idx: np.ndarray | None = None
 
         # Mixed-frequency state augmentation
-        self._flow_variables: list[str] = []
+        self._temporal_aggregation: dict[str, str] = {}
         self._aggregation_period: int = 4
-        self._flow_aggregation: FlowAggregation = "sum"
         self._k_orig_states: int = len(variables)
 
         self.verbose = verbose
@@ -213,47 +211,51 @@ class DSGEStateSpace(PyMCStateSpace):
 
     def _make_design_matrix(self):
         n_cum_lags = self._aggregation_period - 1
+        cumulator_vars = self._cumulator_variables
 
         Z = np.zeros((self.k_endog, self.k_states))
 
         for i, name in enumerate(self.observed_states):
-            if name in self._flow_variables:
-                # Flow: observation = current value + cumulator lags
-                orig_idx = self._orig_state_names.index(name)
-                flow_pos = self._flow_variables.index(name)
-                cum_start = self._k_orig_states + flow_pos * n_cum_lags
+            orig_idx = self._orig_state_names.index(name)
+            agg_method = self._temporal_aggregation.get(name)
 
-                Z[i, orig_idx] = 1.0
-                Z[i, cum_start : cum_start + n_cum_lags] = 1.0
+            if agg_method in CUMULATOR_AGGREGATIONS:
+                agg_pos = cumulator_vars.index(name)
+                cum_start = self._k_orig_states + agg_pos * n_cum_lags
 
-                if self._flow_aggregation == "average":
-                    Z[i, :] /= self._aggregation_period
+                weight = 1.0 / self._aggregation_period if agg_method == "mean" else 1.0
+                Z[i, orig_idx] = weight
+                Z[i, cum_start : cum_start + n_cum_lags] = weight
             else:
-                # Stock: direct selector into original state
-                Z[i, self._orig_state_names.index(name)] = 1.0
+                # first, last, or not specified: direct selector
+                Z[i, orig_idx] = 1.0
 
         return Z
 
     @property
     def _n_cumulator_states(self) -> int:
-        """Total number of cumulator states added for flow variables."""
-        return len(self._flow_variables) * (self._aggregation_period - 1)
+        n_cumulator_vars = sum(1 for m in self._temporal_aggregation.values() if m in CUMULATOR_AGGREGATIONS)
+        return n_cumulator_vars * (self._aggregation_period - 1)
+
+    @property
+    def _cumulator_variables(self) -> list[str]:
+        return [var for var, method in self._temporal_aggregation.items() if method in CUMULATOR_AGGREGATIONS]
 
     @property
     def _orig_state_names(self) -> list[str]:
-        """State names from the original (un-augmented) DSGE model."""
         return [x.base_name for x in self.variables]
 
     @property
     def _cumulator_state_names(self) -> list[str]:
-        """Names of the cumulator auxiliary states."""
         return [
-            f"{var}_cumulator_lag{lag}" for var in self._flow_variables for lag in range(1, self._aggregation_period)
+            f"{var}_cumulator_lag{lag}"
+            for var in self._cumulator_variables
+            for lag in range(1, self._aggregation_period)
         ]
 
     def _augment_transition(self, T: pt.TensorVariable) -> pt.TensorVariable:
         """
-        Augment the transition matrix with cumulator rows/columns for flow variables.
+        Augment the transition matrix with cumulator rows/columns for temporally aggregated variables.
 
         The augmented matrix has the block form::
 
@@ -262,8 +264,8 @@ class DSGEStateSpace(PyMCStateSpace):
                     [ F  |  kron(I_n, C)   ]
 
         where ``C`` is the ``(s-1) × (s-1)`` lower-shift companion matrix (constant, shared
-        by all flow variables), and ``F`` is a loading matrix whose only nonzero rows copy the
-        corresponding flow variable's row from ``T``.
+        by all aggregated variables), and ``F`` is a loading matrix with unit selectors that
+        copy each lagged variable value into the first cumulator position.
 
         Parameters
         ----------
@@ -275,29 +277,26 @@ class DSGEStateSpace(PyMCStateSpace):
         T_aug : pt.TensorVariable
             Augmented (k_orig + n_cum) x (k_orig + n_cum) transition matrix.
         """
-        if not self._flow_variables:
+        cumulator_vars = self._cumulator_variables
+        if not cumulator_vars:
             return T
 
         k_orig = self._k_orig_states
-        n_flow = len(self._flow_variables)
+        n_agg = len(cumulator_vars)
         n_cum_lags = self._aggregation_period - 1
         n_cum = self._n_cumulator_states
         k_aug = k_orig + n_cum
 
-        # Lower-right: block-diagonal of identical companion shift matrices (constant)
-        # C[i, i-1] = 1 for i >= 1; first row is zero (loaded from F instead)
         shift = np.zeros((n_cum_lags, n_cum_lags), dtype=floatX)
         if n_cum_lags > 1:
             shift[np.arange(1, n_cum_lags), np.arange(n_cum_lags - 1)] = 1.0
-        C = np.kron(np.eye(n_flow, dtype=floatX), shift)
+        C = np.kron(np.eye(n_agg, dtype=floatX), shift)
 
-        # Lower-left: loading rows — first cumulator for each flow variable copies T[y_i, :]
-        flow_indices = [self._orig_state_names.index(name) for name in self._flow_variables]
+        agg_indices = [self._orig_state_names.index(name) for name in cumulator_vars]
         F = pt.zeros((n_cum, k_orig), dtype=floatX)
-        for flow_pos, orig_idx in enumerate(flow_indices):
-            F = pt.set_subtensor(F[flow_pos * n_cum_lags, :], T[orig_idx, :])
+        for agg_pos, orig_idx in enumerate(agg_indices):
+            F = pt.set_subtensor(F[agg_pos * n_cum_lags, orig_idx], 1.0)
 
-        # Assemble [[T, 0], [F, C]]
         T_aug = pt.zeros((k_aug, k_aug), dtype=floatX)
         T_aug = pt.set_subtensor(T_aug[:k_orig, :k_orig], T)
         T_aug = pt.set_subtensor(T_aug[k_orig:, :k_orig], F)
@@ -305,17 +304,15 @@ class DSGEStateSpace(PyMCStateSpace):
 
     def _augment_selection(self, R: pt.TensorVariable) -> pt.TensorVariable:
         """
-        Augment the selection matrix with cumulator rows for flow variables.
+        Augment the selection matrix with cumulator rows for temporally aggregated variables.
 
         The augmented matrix has the block form::
 
             R_aug = [ R ]
                     [---]
-                    [ G ]
+                    [ 0 ]
 
-        where ``G`` has one nonzero row per flow variable (the first cumulator), copying
-        the flow variable's shock response from ``R``.  All other cumulator rows are zero
-        because they are deterministic lag shifts.
+        The cumulator rows are all zeros because cumulators are deterministic lag copies.
 
         Parameters
         ----------
@@ -327,24 +324,15 @@ class DSGEStateSpace(PyMCStateSpace):
         R_aug : pt.TensorVariable
             Augmented (k_orig + n_cum) x k_posdef selection matrix.
         """
-        if not self._flow_variables:
+        if not self._cumulator_variables:
             return R
 
         k_orig = self._k_orig_states
-        n_cum_lags = self._aggregation_period - 1
         n_cum = self._n_cumulator_states
         k_aug = k_orig + n_cum
 
-        # Loading: first cumulator of each flow variable inherits its shock response
-        flow_indices = [self._orig_state_names.index(name) for name in self._flow_variables]
-        G = pt.zeros((n_cum, self.k_posdef), dtype=floatX)
-        for flow_pos, orig_idx in enumerate(flow_indices):
-            G = pt.set_subtensor(G[flow_pos * n_cum_lags, :], R[orig_idx, :])
-
-        # Assemble [[R], [G]]
         R_aug = pt.zeros((k_aug, self.k_posdef), dtype=floatX)
-        R_aug = pt.set_subtensor(R_aug[:k_orig, :], R)
-        return pt.set_subtensor(R_aug[k_orig:, :], G)
+        return pt.set_subtensor(R_aug[:k_orig, :], R)
 
     def make_symbolic_graph(self):
         """
@@ -421,10 +409,9 @@ class DSGEStateSpace(PyMCStateSpace):
         measurement_error: list[str] | None = None,
         constant_params: list[str] | Literal["auto"] | None = None,
         full_shock_covaraince: bool = False,
-        flow_variables: list[str] | None = None,
+        temporal_aggregation: dict[str, str] | None = None,
         aggregation_period: int = 4,
-        flow_aggregation: FlowAggregation = "sum",
-        solver: SolverType = "gensys",
+        solver: str = "gensys",
         mode: str | None = None,
         verbose=True,
         max_iter: int = 50,
@@ -445,24 +432,24 @@ class DSGEStateSpace(PyMCStateSpace):
             Parameters held constant (not estimated). ``"auto"`` freezes all parameters without priors.
         full_shock_covaraince : bool
             If True, estimate a full shock covariance matrix instead of diagonal.
-        flow_variables : list of str, optional
-            Observed states that represent flow quantities (e.g. GDP, consumption). When the model
-            frequency is higher than the data frequency, the observation equation for these variables
-            is modified so that the observed value equals the sum (or average) of ``aggregation_period``
-            consecutive high-frequency values. The state vector is augmented with cumulator lags to
-            track the partial sums. Data for flow variables should contain the aggregate value at the
-            last period of each aggregation window, with ``NaN`` at intermediate periods.
+        temporal_aggregation : dict of str to {"sum", "mean", "first", "last"}, optional
+            Observed states that require temporal aggregation or explicit low-frequency timing.
 
-            Stock variables (the default for all observed states) are assumed to be point-in-time
-            and need no special treatment beyond ``NaN``-padding at unobserved periods.
+            - ``"sum"``: Flow variables like GDP (observed = sum of ``aggregation_period`` values).
+              Requires cumulator state augmentation.
+            - ``"mean"``: Rates or prices reported as period averages. Requires cumulator augmentation.
+            - ``"last"``: Point-in-time at end of aggregation window. No cumulator needed.
+              Equivalent to omitting the variable, but explicit about timing.
+            - ``"first"``: Point-in-time at start of aggregation window. No cumulator needed.
+              Data should have values at the first period of each window.
+
+            Variables NOT in this dict use a direct selector — suitable for high-frequency
+            observations (no ``NaN`` in data) or low-frequency point-in-time observations.
+            The Kalman filter handles missing values automatically.
         aggregation_period : int
-            Number of high-frequency periods per low-frequency observation. For example, 4 when
-            fitting a quarterly model with annual data, or 3 for a monthly model with quarterly
-            data. Default is 4.
-        flow_aggregation : str
-            How flow variables are aggregated over the window. ``"sum"`` (default) means the
-            observed value equals the sum of high-frequency values. ``"average"`` divides by
-            ``aggregation_period``.
+            Number of model periods per low-frequency observation. For example, 4 when fitting
+            a quarterly model with annual data, or 3 for a monthly model with quarterly data.
+            Default is 4.
         solver : str
             Perturbation solver to use.
         mode : str, optional
@@ -497,15 +484,25 @@ class DSGEStateSpace(PyMCStateSpace):
                     f"{', '.join(unknown_states)}"
                 )
 
-        # Validate flow variables
-        if flow_variables is None:
-            flow_variables = []
+        # Validate temporal_aggregation
+        if temporal_aggregation is None:
+            temporal_aggregation = {}
         else:
-            unknown_flow = [x for x in flow_variables if x not in observed_states]
-            if len(unknown_flow) > 0:
-                raise ValueError(f"The following flow variables are not in observed_states: {', '.join(unknown_flow)}")
-            if aggregation_period < 2:
-                raise ValueError(f"aggregation_period must be >= 2, got {aggregation_period}")
+            unknown_vars = [x for x in temporal_aggregation if x not in observed_states]
+            if unknown_vars:
+                raise ValueError(
+                    f"The following temporal_aggregation variables are not in observed_states: "
+                    f"{', '.join(unknown_vars)}"
+                )
+            invalid_methods = [
+                (var, method) for var, method in temporal_aggregation.items() if method not in VALID_AGGREGATIONS
+            ]
+            if invalid_methods:
+                bad = ", ".join(f"{var}={method!r}" for var, method in invalid_methods)
+                raise ValueError(f"Invalid aggregation methods: {bad}. Must be 'sum', 'mean', 'first', or 'last'.")
+            has_cumulator_vars = any(m in CUMULATOR_AGGREGATIONS for m in temporal_aggregation.values())
+            if has_cumulator_vars and aggregation_period < 2:
+                raise ValueError(f"aggregation_period must be >= 2 for sum/mean aggregation, got {aggregation_period}")
 
         # Validate constant params
         if constant_params is None:
@@ -523,11 +520,8 @@ class DSGEStateSpace(PyMCStateSpace):
                 )
 
         # Validate solver argument
-        if solver not in valid_solvers:
-            raise ValueError(
-                f'Unknown solver {solver}, expected one of "gensys", "cycle_reduction", '
-                f'"scan_cycle_reduction", or "backward_direct"'
-            )
+        if solver not in VALID_SOLVERS:
+            raise ValueError(f"Unknown solver {solver!r}, expected one of {', '.join(repr(s) for s in VALID_SOLVERS)}")
 
         # Check model is identified
         k_endog = len(observed_states)
@@ -559,10 +553,8 @@ class DSGEStateSpace(PyMCStateSpace):
         self.error_states = measurement_error
         self.constant_parameters = constant_params
 
-        # Store mixed-frequency settings
-        self._flow_variables = flow_variables
+        self._temporal_aggregation = temporal_aggregation
         self._aggregation_period = aggregation_period
-        self._flow_aggregation = flow_aggregation
 
         self.full_covariance = full_shock_covaraince
         self.use_direct_lyapunov = use_direct_lyapunov
@@ -571,11 +563,10 @@ class DSGEStateSpace(PyMCStateSpace):
         self._solver_kwargs = solver_kwargs
         self._mode = mode
 
-        # Compute augmented state dimension
-        n_cumulator = len(flow_variables) * (aggregation_period - 1)
+        n_cumulator_vars = sum(1 for m in temporal_aggregation.values() if m in CUMULATOR_AGGREGATIONS)
+        n_cumulator = n_cumulator_vars * (aggregation_period - 1)
         k_states_aug = self._k_orig_states + n_cumulator
 
-        # Rebuild the internal statespace representation and kalman filters with the newly resized matrices
         super().__init__(
             k_endog,
             k_states_aug,

--- a/gEconpy/model/statespace.py
+++ b/gEconpy/model/statespace.py
@@ -38,6 +38,8 @@ floatX = pytensor.config.floatX
 SolverType = Literal["gensys", "cycle_reduction", "scan_cycle_reduction", "backward_direct"]
 valid_solvers = get_args(SolverType)
 
+FlowAggregation = Literal["sum", "average"]
+
 
 class DSGEStateSpace(PyMCStateSpace):
     """Core class for estimating DSGE models using PyMC."""
@@ -142,6 +144,12 @@ class DSGEStateSpace(PyMCStateSpace):
         self._n_steps = None
         self._lead_var_idx: np.ndarray | None = None
 
+        # Mixed-frequency state augmentation
+        self._flow_variables: list[str] = []
+        self._aggregation_period: int = 4
+        self._flow_aggregation: FlowAggregation = "sum"
+        self._k_orig_states: int = len(variables)
+
         self.verbose = verbose
 
         k_endog = 1  # to be updated later
@@ -204,12 +212,139 @@ class DSGEStateSpace(PyMCStateSpace):
             self.ssm["state_cov", i, i] = sigma**2
 
     def _make_design_matrix(self):
+        n_cum_lags = self._aggregation_period - 1
+
         Z = np.zeros((self.k_endog, self.k_states))
 
         for i, name in enumerate(self.observed_states):
-            Z[i, self.state_names.index(name)] = 1.0
+            if name in self._flow_variables:
+                # Flow: observation = current value + cumulator lags
+                orig_idx = self._orig_state_names.index(name)
+                flow_pos = self._flow_variables.index(name)
+                cum_start = self._k_orig_states + flow_pos * n_cum_lags
+
+                Z[i, orig_idx] = 1.0
+                Z[i, cum_start : cum_start + n_cum_lags] = 1.0
+
+                if self._flow_aggregation == "average":
+                    Z[i, :] /= self._aggregation_period
+            else:
+                # Stock: direct selector into original state
+                Z[i, self._orig_state_names.index(name)] = 1.0
 
         return Z
+
+    @property
+    def _n_cumulator_states(self) -> int:
+        """Total number of cumulator states added for flow variables."""
+        return len(self._flow_variables) * (self._aggregation_period - 1)
+
+    @property
+    def _orig_state_names(self) -> list[str]:
+        """State names from the original (un-augmented) DSGE model."""
+        return [x.base_name for x in self.variables]
+
+    @property
+    def _cumulator_state_names(self) -> list[str]:
+        """Names of the cumulator auxiliary states."""
+        return [
+            f"{var}_cumulator_lag{lag}" for var in self._flow_variables for lag in range(1, self._aggregation_period)
+        ]
+
+    def _augment_transition(self, T: pt.TensorVariable) -> pt.TensorVariable:
+        """
+        Augment the transition matrix with cumulator rows/columns for flow variables.
+
+        The augmented matrix has the block form::
+
+            T_aug = [ T  |  0              ]
+                    [----|-----------------|
+                    [ F  |  kron(I_n, C)   ]
+
+        where ``C`` is the ``(s-1) × (s-1)`` lower-shift companion matrix (constant, shared
+        by all flow variables), and ``F`` is a loading matrix whose only nonzero rows copy the
+        corresponding flow variable's row from ``T``.
+
+        Parameters
+        ----------
+        T : pt.TensorVariable
+            Original k_orig x k_orig transition matrix from the perturbation solution.
+
+        Returns
+        -------
+        T_aug : pt.TensorVariable
+            Augmented (k_orig + n_cum) x (k_orig + n_cum) transition matrix.
+        """
+        if not self._flow_variables:
+            return T
+
+        k_orig = self._k_orig_states
+        n_flow = len(self._flow_variables)
+        n_cum_lags = self._aggregation_period - 1
+        n_cum = self._n_cumulator_states
+        k_aug = k_orig + n_cum
+
+        # Lower-right: block-diagonal of identical companion shift matrices (constant)
+        # C[i, i-1] = 1 for i >= 1; first row is zero (loaded from F instead)
+        shift = np.zeros((n_cum_lags, n_cum_lags), dtype=floatX)
+        if n_cum_lags > 1:
+            shift[np.arange(1, n_cum_lags), np.arange(n_cum_lags - 1)] = 1.0
+        C = np.kron(np.eye(n_flow, dtype=floatX), shift)
+
+        # Lower-left: loading rows — first cumulator for each flow variable copies T[y_i, :]
+        flow_indices = [self._orig_state_names.index(name) for name in self._flow_variables]
+        F = pt.zeros((n_cum, k_orig), dtype=floatX)
+        for flow_pos, orig_idx in enumerate(flow_indices):
+            F = pt.set_subtensor(F[flow_pos * n_cum_lags, :], T[orig_idx, :])
+
+        # Assemble [[T, 0], [F, C]]
+        T_aug = pt.zeros((k_aug, k_aug), dtype=floatX)
+        T_aug = pt.set_subtensor(T_aug[:k_orig, :k_orig], T)
+        T_aug = pt.set_subtensor(T_aug[k_orig:, :k_orig], F)
+        return pt.set_subtensor(T_aug[k_orig:, k_orig:], C)
+
+    def _augment_selection(self, R: pt.TensorVariable) -> pt.TensorVariable:
+        """
+        Augment the selection matrix with cumulator rows for flow variables.
+
+        The augmented matrix has the block form::
+
+            R_aug = [ R ]
+                    [---]
+                    [ G ]
+
+        where ``G`` has one nonzero row per flow variable (the first cumulator), copying
+        the flow variable's shock response from ``R``.  All other cumulator rows are zero
+        because they are deterministic lag shifts.
+
+        Parameters
+        ----------
+        R : pt.TensorVariable
+            Original k_orig x k_posdef selection matrix.
+
+        Returns
+        -------
+        R_aug : pt.TensorVariable
+            Augmented (k_orig + n_cum) x k_posdef selection matrix.
+        """
+        if not self._flow_variables:
+            return R
+
+        k_orig = self._k_orig_states
+        n_cum_lags = self._aggregation_period - 1
+        n_cum = self._n_cumulator_states
+        k_aug = k_orig + n_cum
+
+        # Loading: first cumulator of each flow variable inherits its shock response
+        flow_indices = [self._orig_state_names.index(name) for name in self._flow_variables]
+        G = pt.zeros((n_cum, self.k_posdef), dtype=floatX)
+        for flow_pos, orig_idx in enumerate(flow_indices):
+            G = pt.set_subtensor(G[flow_pos * n_cum_lags, :], R[orig_idx, :])
+
+        # Assemble [[R], [G]]
+        R_aug = pt.zeros((k_aug, self.k_posdef), dtype=floatX)
+        R_aug = pt.set_subtensor(R_aug[:k_orig, :], R)
+        return pt.set_subtensor(R_aug[k_orig:, :], G)
 
     def make_symbolic_graph(self):
         """
@@ -258,8 +393,11 @@ class DSGEStateSpace(PyMCStateSpace):
         self._policy_resid = resid
         self._ss_resid = ss_resid
 
-        self.ssm["transition", :, :] = T
-        self.ssm["selection", :, :] = R
+        T_aug = self._augment_transition(T)
+        R_aug = self._augment_selection(R)
+
+        self.ssm["transition", :, :] = T_aug
+        self.ssm["selection", :, :] = R_aug
         self.ssm["design", :, :] = self._make_design_matrix()
 
         self._setup_state_covariance()
@@ -273,7 +411,9 @@ class DSGEStateSpace(PyMCStateSpace):
 
         Q = self.ssm["state_cov"]
         method = "direct" if self.use_direct_lyapunov else "bilinear"
-        self.ssm["initial_state_cov", :, :] = pt.linalg.solve_discrete_lyapunov(T, R @ Q @ R.T, method=method)
+        self.ssm["initial_state_cov", :, :] = pt.linalg.solve_discrete_lyapunov(
+            T_aug, R_aug @ Q @ R_aug.T, method=method
+        )
 
     def configure(
         self,
@@ -281,6 +421,9 @@ class DSGEStateSpace(PyMCStateSpace):
         measurement_error: list[str] | None = None,
         constant_params: list[str] | Literal["auto"] | None = None,
         full_shock_covaraince: bool = False,
+        flow_variables: list[str] | None = None,
+        aggregation_period: int = 4,
+        flow_aggregation: FlowAggregation = "sum",
         solver: SolverType = "gensys",
         mode: str | None = None,
         verbose=True,
@@ -289,6 +432,52 @@ class DSGEStateSpace(PyMCStateSpace):
         use_adjoint_gradients: bool = True,
         use_direct_lyapunov: bool = False,
     ):
+        """
+        Configure the statespace model for estimation.
+
+        Parameters
+        ----------
+        observed_states : list of str
+            Names of states to treat as observed.
+        measurement_error : list of str, optional
+            Observed states that have measurement error.
+        constant_params : list of str or "auto", optional
+            Parameters held constant (not estimated). ``"auto"`` freezes all parameters without priors.
+        full_shock_covaraince : bool
+            If True, estimate a full shock covariance matrix instead of diagonal.
+        flow_variables : list of str, optional
+            Observed states that represent flow quantities (e.g. GDP, consumption). When the model
+            frequency is higher than the data frequency, the observation equation for these variables
+            is modified so that the observed value equals the sum (or average) of ``aggregation_period``
+            consecutive high-frequency values. The state vector is augmented with cumulator lags to
+            track the partial sums. Data for flow variables should contain the aggregate value at the
+            last period of each aggregation window, with ``NaN`` at intermediate periods.
+
+            Stock variables (the default for all observed states) are assumed to be point-in-time
+            and need no special treatment beyond ``NaN``-padding at unobserved periods.
+        aggregation_period : int
+            Number of high-frequency periods per low-frequency observation. For example, 4 when
+            fitting a quarterly model with annual data, or 3 for a monthly model with quarterly
+            data. Default is 4.
+        flow_aggregation : str
+            How flow variables are aggregated over the window. ``"sum"`` (default) means the
+            observed value equals the sum of high-frequency values. ``"average"`` divides by
+            ``aggregation_period``.
+        solver : str
+            Perturbation solver to use.
+        mode : str, optional
+            PyTensor compilation mode.
+        verbose : bool
+            Print diagnostic messages.
+        max_iter : int
+            Maximum iterations for iterative solvers.
+        tol : float
+            Convergence tolerance for the solver.
+        use_adjoint_gradients : bool
+            Use adjoint gradients in ``scan_cycle_reduction``.
+        use_direct_lyapunov : bool
+            Use direct (rather than bilinear) Lyapunov solver.
+        """
         # Set up observed states
         unknown_states = [x for x in observed_states if x not in self.state_names]
         if len(unknown_states) > 0:
@@ -307,6 +496,16 @@ class DSGEStateSpace(PyMCStateSpace):
                     f"The following states are not observed, and cannot have measurement error: "
                     f"{', '.join(unknown_states)}"
                 )
+
+        # Validate flow variables
+        if flow_variables is None:
+            flow_variables = []
+        else:
+            unknown_flow = [x for x in flow_variables if x not in observed_states]
+            if len(unknown_flow) > 0:
+                raise ValueError(f"The following flow variables are not in observed_states: {', '.join(unknown_flow)}")
+            if aggregation_period < 2:
+                raise ValueError(f"aggregation_period must be >= 2, got {aggregation_period}")
 
         # Validate constant params
         if constant_params is None:
@@ -360,6 +559,11 @@ class DSGEStateSpace(PyMCStateSpace):
         self.error_states = measurement_error
         self.constant_parameters = constant_params
 
+        # Store mixed-frequency settings
+        self._flow_variables = flow_variables
+        self._aggregation_period = aggregation_period
+        self._flow_aggregation = flow_aggregation
+
         self.full_covariance = full_shock_covaraince
         self.use_direct_lyapunov = use_direct_lyapunov
         self._configured = True
@@ -367,10 +571,14 @@ class DSGEStateSpace(PyMCStateSpace):
         self._solver_kwargs = solver_kwargs
         self._mode = mode
 
+        # Compute augmented state dimension
+        n_cumulator = len(flow_variables) * (aggregation_period - 1)
+        k_states_aug = self._k_orig_states + n_cumulator
+
         # Rebuild the internal statespace representation and kalman filters with the newly resized matrices
         super().__init__(
             k_endog,
-            self.k_states,
+            k_states_aug,
             self.k_posdef,
             measurement_error=len(measurement_error) > 0,
             verbose=verbose,
@@ -385,8 +593,9 @@ class DSGEStateSpace(PyMCStateSpace):
     def set_states(self) -> tuple[State, ...]:
         observed_states = self._obs_state_names if self._obs_state_names is not None else []
         hidden_states = [State(name=x.base_name, observed=False) for x in self.variables]
+        cumulator_states = [State(name=name, observed=False) for name in self._cumulator_state_names]
         observed_states = [State(name=name, observed=True) for name in observed_states]
-        return *hidden_states, *observed_states
+        return *hidden_states, *cumulator_states, *observed_states
 
     def set_parameters(self) -> tuple[Parameter, ...]:
         # TODO: Extract information from assumptions and use them to denote constraints on the parameters
@@ -638,3 +847,79 @@ def data_from_prior(
     statepace_mod._fit_coords = None
 
     return true_params, data, prior_idata
+
+
+def prepare_mixed_frequency_data(
+    low_freq_data: pd.DataFrame,
+    high_freq: str,
+    aggregation_period: int = 4,
+    observation_position: Literal["first", "last"] = "last",
+) -> pd.DataFrame:
+    """
+    Expand low-frequency data to a high-frequency index for mixed-frequency estimation.
+
+    Each low-frequency value is placed at the first or last high-frequency period within
+    its aggregation window, with ``NaN`` at all other periods.  The Kalman filter treats
+    ``NaN`` entries as missing observations.
+
+    The flow-vs-stock distinction is irrelevant here — both are placed identically.  The
+    distinction only matters in :meth:`DSGEStateSpace.configure`, where ``flow_variables``
+    triggers cumulator-state augmentation so the observation equation sums over the window.
+
+    Parameters
+    ----------
+    low_freq_data : pd.DataFrame
+        Observed data at low frequency.  The index should be a ``DatetimeIndex`` at the
+        low-frequency periodicity (e.g. annual).  Each column corresponds to an observed
+        variable.
+    high_freq : str
+        Pandas frequency string for the high-frequency (model) periodicity, e.g. ``"QS"``
+        for quarterly.
+    aggregation_period : int
+        Number of high-frequency periods per low-frequency observation.  Default is 4
+        (annual from quarterly).
+    observation_position : str
+        Whether the low-frequency observation corresponds to the ``"first"`` or ``"last"``
+        high-frequency period in each window.  Default is ``"last"``.
+
+    Returns
+    -------
+    pd.DataFrame
+        High-frequency DataFrame with ``NaN`` at unobserved periods.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        import pandas as pd
+
+        annual = pd.DataFrame(
+            {"GDP": [100, 110], "R": [0.05, 0.04]},
+            index=pd.to_datetime(["2020", "2021"]),
+        )
+        quarterly = prepare_mixed_frequency_data(annual, high_freq="QS")
+    """
+    pos_idx = 0 if observation_position == "first" else aggregation_period - 1
+
+    all_columns = list(low_freq_data.columns)
+    first_date = low_freq_data.index.min()
+    hf_index = pd.date_range(start=first_date, periods=len(low_freq_data) * aggregation_period, freq=high_freq)
+
+    result = pd.DataFrame(np.nan, index=hf_index, columns=all_columns)
+
+    for _, row in low_freq_data.iterrows():
+        lf_date = row.name
+        window_periods = hf_index[(hf_index >= lf_date)][:aggregation_period]
+
+        if len(window_periods) <= pos_idx:
+            continue
+
+        result.loc[window_periods[pos_idx]] = row
+
+    # Trim trailing all-NaN rows beyond the last observation window
+    last_obs_idx = result.last_valid_index()
+    if last_obs_idx is not None:
+        result = result.loc[:last_obs_idx]
+
+    result.index.freq = result.index.inferred_freq
+    return result

--- a/tests/model/test_statespace.py
+++ b/tests/model/test_statespace.py
@@ -12,6 +12,21 @@ from tests._resources.cache_compiled_models import (
 )
 
 
+@pytest.fixture
+def rbc_statespace():
+    return statespace_from_gcn("tests/_resources/test_gcns/rbc_linearized.gcn", verbose=False)
+
+
+def _eval_augmented_matrices(ss_mod):
+    inputs = pm.inputvars(ss_mod.linearized_system)
+    input_names = [x.name for x in inputs]
+    f = pytensor.function(inputs, [ss_mod.ssm["transition"], ss_mod.ssm["selection"]], on_unused_input="ignore")
+    param_dict = load_and_cache_model("rbc_linearized.gcn").parameters()
+    T, R = f(**{k: param_dict[k] for k in input_names})
+    Z = ss_mod._make_design_matrix()
+    return T, R, Z
+
+
 @pytest.mark.parametrize(
     "gcn_file",
     [
@@ -48,62 +63,40 @@ def test_statespace_matrices_agree_with_model(gcn_file):
         "sarima2_12.gcn",
     ],
 )
-def test_model_to_pymc(gcn_file):
+def test_to_pymc_creates_rvs_for_priors(gcn_file):
     ss_mod = load_and_cache_statespace(gcn_file)
     with pm.Model() as m:
         ss_mod.to_pymc()
-    rv_names = [rv.name for rv in m.free_RVs]
+    rv_names = {rv.name for rv in m.free_RVs}
 
-    assert all(name in rv_names for name in ss_mod.param_priors)
+    assert set(ss_mod.param_priors.keys()) <= rv_names
 
-    hyper_prior_names = [
+    hyper_prior_names = {
         name for dist in ss_mod.shock_priors.values() for name in dist.param_name_to_hyper_name.values()
-    ]
-
-    assert all(name in rv_names for name in hyper_prior_names)
-
-
-@pytest.mark.parametrize(
-    "gcn_file",
-    [
-        "one_block_1_ss.gcn",
-        "open_rbc.gcn",
-        pytest.param("full_nk.gcn", marks=pytest.mark.include_nk),
-        "rbc_linearized.gcn",
-        "sarima2_12.gcn",
-    ],
-)
-def test_model_config(gcn_file):
-    ss_mod = load_and_cache_statespace(gcn_file)
+    }
+    assert hyper_prior_names <= rv_names
 
 
-def test_backward_direct_statespace_logp():
+def test_backward_direct_solver_produces_finite_logp():
     ss_mod = load_and_cache_statespace("sarima2_12.gcn")
-    ss_mod.configure(
-        observed_states=["x"],
-        solver="backward_direct",
-        verbose=False,
-    )
+    ss_mod.configure(observed_states=["x"], solver="backward_direct", verbose=False)
 
     rng = np.random.default_rng()
-    n_obs = 100
     data = pd.DataFrame(
-        rng.normal(size=(n_obs,)),
+        rng.normal(size=(100,)),
         columns=["x"],
-        index=pd.date_range("2000-01-01", periods=n_obs, freq="MS"),
+        index=pd.date_range("2000-01-01", periods=100, freq="MS"),
     )
 
     with pm.Model() as m:
         ss_mod.to_pymc()
         ss_mod.build_statespace_graph(data)
-
-        point = m.initial_point()
-        logp = m.compile_logp()(point)
+        logp = m.compile_logp()(m.initial_point())
         assert np.isfinite(logp)
 
 
 @pytest.mark.filterwarnings("ignore:Provided data contains missing values and will be automatically imputed")
-def test_data_from_prior_with_constant_params():
+def test_constant_params_excluded_from_prior_samples():
     ss_mod = statespace_from_gcn("tests/_resources/test_gcns/rbc_linearized.gcn", verbose=False)
     ss_mod.configure(
         observed_states=["Y", "C", "L"],
@@ -120,172 +113,227 @@ def test_data_from_prior_with_constant_params():
         for var_name in ss_mod.observed_states:
             pm.Gamma(f"error_sigma_{var_name}", alpha=2, beta=100)
 
-    true_params, data, _prior_idata = data_from_prior(
-        ss_mod,
-        pm_mod,
-        n_samples=5,
-        random_seed=42,
-    )
+    true_params, data, _ = data_from_prior(ss_mod, pm_mod, n_samples=5, random_seed=17031)
 
     assert data.shape[1] == 3
     assert "beta" not in true_params.data_vars
     assert "delta" not in true_params.data_vars
 
 
-def test_constant_params_auto():
+def test_constant_params_auto_excludes_priorless_params():
     ss_mod = statespace_from_gcn("tests/_resources/test_gcns/open_rbc.gcn", verbose=False)
-    ss_mod.configure(
-        observed_states=["Y"],
-        constant_params="auto",
-        solver="scan_cycle_reduction",
-        verbose=False,
-    )
+    ss_mod.configure(observed_states=["Y"], constant_params="auto", solver="scan_cycle_reduction", verbose=False)
 
     params_with_priors = set(ss_mod.param_priors.keys())
     input_param_names = {x.name for x in ss_mod.input_parameters}
     expected_constant = input_param_names - params_with_priors
 
-    assert len(expected_constant) > 0, "Test requires a model with some prior-less parameters"
+    assert expected_constant, "Test requires a model with some prior-less parameters"
     assert set(ss_mod.constant_parameters) == expected_constant
-
-    # Constant params should not appear in param_names
-    for name in expected_constant:
-        assert name not in ss_mod.param_names
-
-    # Params with priors should still be free
-    for name in params_with_priors:
-        assert name in ss_mod.param_names
+    assert not (expected_constant & set(ss_mod.param_names))
+    assert params_with_priors <= set(ss_mod.param_names)
 
 
-def _eval_augmented_matrices(ss_mod):
-    """Compile and evaluate the augmented T, R, Z matrices at default parameter values."""
-    inputs = pm.inputvars(ss_mod.linearized_system)
-    input_names = [x.name for x in inputs]
-    f = pytensor.function(inputs, [ss_mod.ssm["transition"], ss_mod.ssm["selection"]], on_unused_input="ignore")
-    param_dict = load_and_cache_model("rbc_linearized.gcn").parameters()
-    T, R = f(**{k: param_dict[k] for k in input_names})
-    Z = ss_mod._make_design_matrix()
-    return T, R, Z
-
-
-def test_cumulator_augmentation_structure():
-    """T, R, Z matrices have correct cumulator block for flow variable temporal aggregation."""
-    ss_mod = statespace_from_gcn("tests/_resources/test_gcns/rbc_linearized.gcn", verbose=False)
-    ss_mod.configure(
+def test_temporal_aggregation_sum_accumulates_over_window(rbc_statespace):
+    rbc_statespace.configure(
         observed_states=["Y"],
-        flow_variables=["Y"],
+        temporal_aggregation={"Y": "sum"},
         solver="gensys",
         verbose=False,
     )
-    T, R, Z = _eval_augmented_matrices(ss_mod)
+    T, _R, Z = _eval_augmented_matrices(rbc_statespace)
 
-    k_orig = ss_mod._k_orig_states
-    y_idx = ss_mod._orig_state_names.index("Y")
+    k_orig = rbc_statespace._k_orig_states
+    y_idx = rbc_statespace._orig_state_names.index("Y")
 
-    # Transition: first cumulator copies Y row; remaining shift by one
-    np.testing.assert_allclose(T[k_orig, :k_orig], T[y_idx, :k_orig], atol=1e-10)
-    assert T[k_orig + 1, k_orig] == 1.0
-    assert T[k_orig + 2, k_orig + 1] == 1.0
+    rng = np.random.default_rng()
+    x = np.zeros(T.shape[0])
+    x[:k_orig] = rng.normal(0, 0.1, size=k_orig)
 
-    # Selection: first cumulator inherits Y's shock response; rest zero
-    np.testing.assert_allclose(R[k_orig, :], R[y_idx, :], atol=1e-10)
-    np.testing.assert_allclose(R[k_orig + 1 :, :], 0.0, atol=1e-10)
+    quarterly_Y = [x[y_idx]]
+    for _ in range(3):
+        x = T @ x
+        quarterly_Y.append(x[y_idx])
 
-    # Design: sums current Y + 3 cumulator lags
-    expected_Z = np.zeros_like(Z)
-    expected_Z[0, y_idx] = 1.0
-    expected_Z[0, k_orig : k_orig + 3] = 1.0
-    np.testing.assert_allclose(Z, expected_Z)
+    observation = (Z @ x)[0]
+    np.testing.assert_allclose(observation, sum(quarterly_Y), rtol=1e-10)
 
 
-def test_mixed_flow_and_stock_design():
-    """With Y as flow and K as stock, Z has cumulator sum for Y and a plain selector for K."""
-    ss_mod = statespace_from_gcn("tests/_resources/test_gcns/rbc_linearized.gcn", verbose=False)
-    ss_mod.configure(
+@pytest.mark.parametrize("aggregation,weight", [("sum", 1.0), ("mean", 0.25)])
+def test_temporal_aggregation_design_matrix_weighting(rbc_statespace, aggregation, weight):
+    rbc_statespace.configure(
+        observed_states=["Y"],
+        temporal_aggregation={"Y": aggregation},
+        solver="gensys",
+        verbose=False,
+    )
+    Z = rbc_statespace._make_design_matrix()
+    np.testing.assert_allclose(Z[0, Z[0] != 0], weight)
+
+
+def test_aggregated_and_direct_variables_have_correct_design_rows(rbc_statespace):
+    rbc_statespace.configure(
         observed_states=["Y", "K"],
         measurement_error=["Y", "K"],
-        flow_variables=["Y"],
+        temporal_aggregation={"Y": "sum"},
         solver="gensys",
         verbose=False,
     )
-    _T, _R, Z = _eval_augmented_matrices(ss_mod)
+    _T, _R, Z = _eval_augmented_matrices(rbc_statespace)
 
-    k_orig = ss_mod._k_orig_states
-    orig_names = ss_mod._orig_state_names
-    y_idx = orig_names.index("Y")
-    k_idx = orig_names.index("K")
+    k_orig = rbc_statespace._k_orig_states
+    y_idx = rbc_statespace._orig_state_names.index("Y")
+    k_idx = rbc_statespace._orig_state_names.index("K")
 
-    # Y row: sums current + 3 cumulator lags (flow)
-    expected_y_row = np.zeros(ss_mod.k_states)
+    expected_y_row = np.zeros(rbc_statespace.k_states)
     expected_y_row[y_idx] = 1.0
     expected_y_row[k_orig : k_orig + 3] = 1.0
     np.testing.assert_allclose(Z[0], expected_y_row)
 
-    # K row: plain selector into original state block (stock)
-    expected_k_row = np.zeros(ss_mod.k_states)
+    expected_k_row = np.zeros(rbc_statespace.k_states)
     expected_k_row[k_idx] = 1.0
     np.testing.assert_allclose(Z[1], expected_k_row)
 
 
-@pytest.mark.parametrize("aggregation,weight", [("sum", 1.0), ("average", 0.25)])
-def test_flow_design_matrix_weighting(aggregation, weight):
-    """Design matrix entries scale correctly for sum vs average temporal aggregation."""
-    ss_mod = statespace_from_gcn("tests/_resources/test_gcns/rbc_linearized.gcn", verbose=False)
-    ss_mod.configure(
-        observed_states=["Y"],
-        flow_variables=["Y"],
-        flow_aggregation=aggregation,
-        solver="gensys",
-        verbose=False,
-    )
-    Z = ss_mod._make_design_matrix()
-    np.testing.assert_allclose(Z[0, Z[0] != 0], weight)
-
-
 @pytest.mark.filterwarnings("ignore:Provided data contains missing values")
-def test_mixed_frequency_logp():
-    """Kalman filter produces finite logp with NaN-padded annual data on flow + stock obs."""
-    ss_mod = statespace_from_gcn("tests/_resources/test_gcns/rbc_linearized.gcn", verbose=False)
-    ss_mod.configure(
+def test_mixed_frequency_data_produces_finite_logp(rbc_statespace):
+    rbc_statespace.configure(
         observed_states=["Y", "K"],
         measurement_error=["Y", "K"],
-        flow_variables=["Y"],
+        temporal_aggregation={"Y": "sum"},
         solver="gensys",
         verbose=False,
     )
 
-    rng = np.random.default_rng(42)
+    rng = np.random.default_rng()
     n_quarters = 40
     hf_index = pd.date_range("2000-01-01", periods=n_quarters, freq="QS")
-    data = pd.DataFrame(np.nan, index=hf_index, columns=["Y", "K"])
-    data.iloc[3::4] = rng.normal(0, 0.1, size=(n_quarters // 4, 2))
+
+    data = pd.DataFrame(index=hf_index, columns=["Y", "K"])
+    data["Y"] = np.nan
+    data.loc[data.index[3::4], "Y"] = rng.normal(0, 0.1, size=n_quarters // 4)
+    data["K"] = rng.normal(0, 0.1, size=n_quarters)
 
     with pm.Model():
-        ss_mod.to_pymc()
+        rbc_statespace.to_pymc()
         pm.Gamma("sigma_epsilon_A", alpha=2, beta=100)
         pm.Gamma("error_sigma_Y", alpha=2, beta=100)
         pm.Gamma("error_sigma_K", alpha=2, beta=100)
-        ss_mod.build_statespace_graph(data, add_norm_check=False)
+        rbc_statespace.build_statespace_graph(data, add_norm_check=False)
         logp = pm.modelcontext(None).compile_logp()(pm.modelcontext(None).initial_point())
         assert np.isfinite(logp)
 
 
-def test_prepare_mixed_frequency_data():
-    """Annual data expands to quarterly with values at correct positions and NaN elsewhere."""
+@pytest.mark.parametrize(
+    "aggregation_period,expected_shape",
+    [(4, (3, 3)), (3, (2, 2)), (2, (1, 1))],
+    ids=["quarterly-to-annual", "monthly-to-quarterly", "period-2"],
+)
+def test_cumulator_shift_matrix_shape_matches_aggregation_period(rbc_statespace, aggregation_period, expected_shape):
+    rbc_statespace.configure(
+        observed_states=["Y"],
+        temporal_aggregation={"Y": "sum"},
+        aggregation_period=aggregation_period,
+        solver="gensys",
+        verbose=False,
+    )
+    T, _R, _Z = _eval_augmented_matrices(rbc_statespace)
+    k_orig = rbc_statespace._k_orig_states
+    C = T[k_orig:, k_orig:]
+    assert C.shape == expected_shape
+
+
+def test_multiple_aggregated_variables_produce_block_diagonal_structure(rbc_statespace):
+    rbc_statespace.configure(
+        observed_states=["Y", "C"],
+        measurement_error=["Y", "C"],
+        temporal_aggregation={"Y": "sum", "C": "sum"},
+        aggregation_period=4,
+        solver="gensys",
+        verbose=False,
+    )
+    T, _R, _Z = _eval_augmented_matrices(rbc_statespace)
+
+    k_orig = rbc_statespace._k_orig_states
+    C = T[k_orig:, k_orig:]
+
+    shift = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=np.float32)
+    expected_C = np.kron(np.eye(2, dtype=np.float32), shift)
+    np.testing.assert_allclose(C, expected_C)
+
+
+@pytest.mark.parametrize("observation_position", ["first", "last"])
+def test_prepare_mixed_frequency_data_positions_values_correctly(observation_position):
     annual = pd.DataFrame(
         {"GDP": [100.0, 110.0], "R": [0.05, 0.04]},
         index=pd.to_datetime(["2020-01-01", "2021-01-01"]),
     )
 
-    # Default: all columns at Q4 (last period)
-    quarterly = prepare_mixed_frequency_data(annual, high_freq="QS")
-    assert quarterly.shape == (8, 2)
-    np.testing.assert_array_equal(quarterly.iloc[3].values, [100.0, 0.05])
-    np.testing.assert_array_equal(quarterly.iloc[7].values, [110.0, 0.04])
-    assert quarterly.isna().sum().sum() == 12
+    quarterly = prepare_mixed_frequency_data(annual, high_freq="QS", observation_position=observation_position)
 
-    # First period: all columns at Q1
-    quarterly = prepare_mixed_frequency_data(annual, high_freq="QS", observation_position="first")
-    assert quarterly.loc["2020-01-01", "GDP"] == 100.0
-    assert quarterly.loc["2020-01-01", "R"] == 0.05
-    assert np.isnan(quarterly.loc["2020-10-01", "GDP"])
+    if observation_position == "last":
+        assert quarterly.shape == (8, 2)
+        np.testing.assert_array_equal(quarterly.iloc[3].values, [100.0, 0.05])
+        np.testing.assert_array_equal(quarterly.iloc[7].values, [110.0, 0.04])
+    else:
+        assert quarterly.loc["2020-01-01", "GDP"] == 100.0
+        assert quarterly.loc["2021-01-01", "GDP"] == 110.0
+
+
+@pytest.mark.parametrize(
+    "high_freq,aggregation_period,expected_len,value_position",
+    [("MS", 12, 12, "2020-12-01"), ("MS", 3, 6, "2020-03-01")],
+    ids=["monthly-to-annual", "monthly-to-quarterly"],
+)
+def test_prepare_mixed_frequency_data_various_periods(high_freq, aggregation_period, expected_len, value_position):
+    low_freq = pd.DataFrame({"GDP": [100.0]}, index=pd.to_datetime(["2020-01-01"]))
+    if aggregation_period == 3:
+        low_freq = pd.DataFrame({"GDP": [100.0, 110.0]}, index=pd.to_datetime(["2020-01-01", "2020-04-01"]))
+
+    result = prepare_mixed_frequency_data(
+        low_freq, high_freq=high_freq, aggregation_period=aggregation_period, observation_position="last"
+    )
+
+    assert len(result) == expected_len
+    assert result.loc[value_position, "GDP"] == 100.0
+
+
+def test_mixed_sum_and_mean_aggregation_weights(rbc_statespace):
+    rbc_statespace.configure(
+        observed_states=["Y", "C"],
+        measurement_error=["Y", "C"],
+        temporal_aggregation={"Y": "sum", "C": "mean"},
+        aggregation_period=4,
+        solver="gensys",
+        verbose=False,
+    )
+    _T, _R, Z = _eval_augmented_matrices(rbc_statespace)
+
+    k_orig = rbc_statespace._k_orig_states
+    y_idx = rbc_statespace._orig_state_names.index("Y")
+    c_idx = rbc_statespace._orig_state_names.index("C")
+
+    np.testing.assert_allclose(Z[0, y_idx], 1.0)
+    np.testing.assert_allclose(Z[0, k_orig : k_orig + 3], 1.0)
+
+    np.testing.assert_allclose(Z[1, c_idx], 0.25)
+    np.testing.assert_allclose(Z[1, k_orig + 3 : k_orig + 6], 0.25)
+
+
+@pytest.mark.parametrize("method", ["first", "last"])
+def test_first_and_last_aggregation_use_direct_selector(rbc_statespace, method):
+    rbc_statespace.configure(
+        observed_states=["Y"],
+        temporal_aggregation={"Y": method},
+        solver="gensys",
+        verbose=False,
+    )
+
+    assert rbc_statespace._n_cumulator_states == 0
+
+    _T, _R, Z = _eval_augmented_matrices(rbc_statespace)
+    y_idx = rbc_statespace._orig_state_names.index("Y")
+
+    expected_row = np.zeros(rbc_statespace.k_states)
+    expected_row[y_idx] = 1.0
+    np.testing.assert_allclose(Z[0], expected_row)

--- a/tests/model/test_statespace.py
+++ b/tests/model/test_statespace.py
@@ -1,5 +1,3 @@
-import warnings
-
 import numpy as np
 import pandas as pd
 import pymc as pm
@@ -7,7 +5,7 @@ import pytensor
 import pytest
 
 from gEconpy import statespace_from_gcn
-from gEconpy.model.statespace import data_from_prior
+from gEconpy.model.statespace import data_from_prior, prepare_mixed_frequency_data
 from tests._resources.cache_compiled_models import (
     load_and_cache_model,
     load_and_cache_statespace,
@@ -157,3 +155,137 @@ def test_constant_params_auto():
     # Params with priors should still be free
     for name in params_with_priors:
         assert name in ss_mod.param_names
+
+
+def _eval_augmented_matrices(ss_mod):
+    """Compile and evaluate the augmented T, R, Z matrices at default parameter values."""
+    inputs = pm.inputvars(ss_mod.linearized_system)
+    input_names = [x.name for x in inputs]
+    f = pytensor.function(inputs, [ss_mod.ssm["transition"], ss_mod.ssm["selection"]], on_unused_input="ignore")
+    param_dict = load_and_cache_model("rbc_linearized.gcn").parameters()
+    T, R = f(**{k: param_dict[k] for k in input_names})
+    Z = ss_mod._make_design_matrix()
+    return T, R, Z
+
+
+def test_cumulator_augmentation_structure():
+    """T, R, Z matrices have correct cumulator block for flow variable temporal aggregation."""
+    ss_mod = statespace_from_gcn("tests/_resources/test_gcns/rbc_linearized.gcn", verbose=False)
+    ss_mod.configure(
+        observed_states=["Y"],
+        flow_variables=["Y"],
+        solver="gensys",
+        verbose=False,
+    )
+    T, R, Z = _eval_augmented_matrices(ss_mod)
+
+    k_orig = ss_mod._k_orig_states
+    y_idx = ss_mod._orig_state_names.index("Y")
+
+    # Transition: first cumulator copies Y row; remaining shift by one
+    np.testing.assert_allclose(T[k_orig, :k_orig], T[y_idx, :k_orig], atol=1e-10)
+    assert T[k_orig + 1, k_orig] == 1.0
+    assert T[k_orig + 2, k_orig + 1] == 1.0
+
+    # Selection: first cumulator inherits Y's shock response; rest zero
+    np.testing.assert_allclose(R[k_orig, :], R[y_idx, :], atol=1e-10)
+    np.testing.assert_allclose(R[k_orig + 1 :, :], 0.0, atol=1e-10)
+
+    # Design: sums current Y + 3 cumulator lags
+    expected_Z = np.zeros_like(Z)
+    expected_Z[0, y_idx] = 1.0
+    expected_Z[0, k_orig : k_orig + 3] = 1.0
+    np.testing.assert_allclose(Z, expected_Z)
+
+
+def test_mixed_flow_and_stock_design():
+    """With Y as flow and K as stock, Z has cumulator sum for Y and a plain selector for K."""
+    ss_mod = statespace_from_gcn("tests/_resources/test_gcns/rbc_linearized.gcn", verbose=False)
+    ss_mod.configure(
+        observed_states=["Y", "K"],
+        measurement_error=["Y", "K"],
+        flow_variables=["Y"],
+        solver="gensys",
+        verbose=False,
+    )
+    _T, _R, Z = _eval_augmented_matrices(ss_mod)
+
+    k_orig = ss_mod._k_orig_states
+    orig_names = ss_mod._orig_state_names
+    y_idx = orig_names.index("Y")
+    k_idx = orig_names.index("K")
+
+    # Y row: sums current + 3 cumulator lags (flow)
+    expected_y_row = np.zeros(ss_mod.k_states)
+    expected_y_row[y_idx] = 1.0
+    expected_y_row[k_orig : k_orig + 3] = 1.0
+    np.testing.assert_allclose(Z[0], expected_y_row)
+
+    # K row: plain selector into original state block (stock)
+    expected_k_row = np.zeros(ss_mod.k_states)
+    expected_k_row[k_idx] = 1.0
+    np.testing.assert_allclose(Z[1], expected_k_row)
+
+
+@pytest.mark.parametrize("aggregation,weight", [("sum", 1.0), ("average", 0.25)])
+def test_flow_design_matrix_weighting(aggregation, weight):
+    """Design matrix entries scale correctly for sum vs average temporal aggregation."""
+    ss_mod = statespace_from_gcn("tests/_resources/test_gcns/rbc_linearized.gcn", verbose=False)
+    ss_mod.configure(
+        observed_states=["Y"],
+        flow_variables=["Y"],
+        flow_aggregation=aggregation,
+        solver="gensys",
+        verbose=False,
+    )
+    Z = ss_mod._make_design_matrix()
+    np.testing.assert_allclose(Z[0, Z[0] != 0], weight)
+
+
+@pytest.mark.filterwarnings("ignore:Provided data contains missing values")
+def test_mixed_frequency_logp():
+    """Kalman filter produces finite logp with NaN-padded annual data on flow + stock obs."""
+    ss_mod = statespace_from_gcn("tests/_resources/test_gcns/rbc_linearized.gcn", verbose=False)
+    ss_mod.configure(
+        observed_states=["Y", "K"],
+        measurement_error=["Y", "K"],
+        flow_variables=["Y"],
+        solver="gensys",
+        verbose=False,
+    )
+
+    rng = np.random.default_rng(42)
+    n_quarters = 40
+    hf_index = pd.date_range("2000-01-01", periods=n_quarters, freq="QS")
+    data = pd.DataFrame(np.nan, index=hf_index, columns=["Y", "K"])
+    data.iloc[3::4] = rng.normal(0, 0.1, size=(n_quarters // 4, 2))
+
+    with pm.Model():
+        ss_mod.to_pymc()
+        pm.Gamma("sigma_epsilon_A", alpha=2, beta=100)
+        pm.Gamma("error_sigma_Y", alpha=2, beta=100)
+        pm.Gamma("error_sigma_K", alpha=2, beta=100)
+        ss_mod.build_statespace_graph(data, add_norm_check=False)
+        logp = pm.modelcontext(None).compile_logp()(pm.modelcontext(None).initial_point())
+        assert np.isfinite(logp)
+
+
+def test_prepare_mixed_frequency_data():
+    """Annual data expands to quarterly with values at correct positions and NaN elsewhere."""
+    annual = pd.DataFrame(
+        {"GDP": [100.0, 110.0], "R": [0.05, 0.04]},
+        index=pd.to_datetime(["2020-01-01", "2021-01-01"]),
+    )
+
+    # Default: all columns at Q4 (last period)
+    quarterly = prepare_mixed_frequency_data(annual, high_freq="QS")
+    assert quarterly.shape == (8, 2)
+    np.testing.assert_array_equal(quarterly.iloc[3].values, [100.0, 0.05])
+    np.testing.assert_array_equal(quarterly.iloc[7].values, [110.0, 0.04])
+    assert quarterly.isna().sum().sum() == 12
+
+    # First period: all columns at Q1
+    quarterly = prepare_mixed_frequency_data(annual, high_freq="QS", observation_position="first")
+    assert quarterly.loc["2020-01-01", "GDP"] == 100.0
+    assert quarterly.loc["2020-01-01", "R"] == 0.05
+    assert np.isnan(quarterly.loc["2020-10-01", "GDP"])


### PR DESCRIPTION
Add options to DSGEStateSpace.config to allow for mixed low/high frequency observed data. This adds a stock-flow consistent adjustment to the transition, selection, and design matrices, forcing high-frequency latent states to aggregate sum/average/first/last back up to the low-frequency observations.

<!-- readthedocs-preview gEconpy start -->
----
📚 Documentation preview 📚: https://gEconpy--86.org.readthedocs.build/en/86/

<!-- readthedocs-preview gEconpy end -->