### PR TITLE
Add support for minimization problems 

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ block FIRM
 
     objective
     {
-        TC[] = -(r[] * K[-1] + w[] * L[]);
+        @minimize
+        TC[] = r[] * K[-1] + w[] * L[];
     };
 
     constraints
@@ -140,6 +141,8 @@ The multiplier associated with the budget constraint has been given the variable
 
 Internally, first order conditions are solved by first making all substitutions from `definitions`, then forming the following Lagrangian function:
 `L = objective.RHS - lm1 * (control_1.LHS - control_1.RHS) - lm2 * (control_2.LHS - control_2.RHS) ... - lm_k * (control_k.LHS - control_k.RHS)`
+
+When the objective carries the `@minimize` tag, the objective RHS is negated before forming the Lagrangian, converting the minimization into an equivalent maximization.
 
 Next, the derivative of this Lagrangian is taken with respect to all control variables and all lagrange multipliers. Derivatives are are computed "though time" using `TimeAwareSymbols`, an extension of a normal Sympy symbol. For a control variable x, the total derivative over time is built up as `dL[]/dx[] + beta * dL[+1]/dx + beta * beta * dL[+2]/dx[] ...`.
 

--- a/conda_envs/geconpy_test.yml
+++ b/conda_envs/geconpy_test.yml
@@ -12,7 +12,7 @@ dependencies:
   - pandas
   - xarray
   - matplotlib
-  - arviz
+  - arviz<1.0
   - statsmodels
   - pymc>=5.27.1
   - pytensor>=2.37.0

--- a/docs/source/get_started/overview.rst
+++ b/docs/source/get_started/overview.rst
@@ -82,7 +82,8 @@ As an alternative to setting a parameter value directly, the user can declare a 
 
         objective
         {
-            TC[] = -(r[] * K[-1] + w[] * L[]);
+            @minimize
+            TC[] = r[] * K[-1] + w[] * L[];
         };
 
         constraints
@@ -120,6 +121,8 @@ The multiplier associated with the budget constraint has been given the name "la
 
 Interally, first order conditions are solved by first making all substitutions from ``definitions``, then forming the following Lagrangian function:
 ``L = objective.RHS - lm1 * (control_1.LHS - control_1.RHS) - lm2 * (control_2.LHS - control_2.RHS) ... - lm_k * (control_k.LHS - control_k.RHS)``
+
+When the objective carries the ``@minimize`` tag, the objective RHS is negated before forming the Lagrangian, converting the minimization into an equivalent maximization.
 
 Next, the derivative of this Lagrangian is taken with respect to all control variables and all lagrange multipliers. Derivaties are are computed "though time" using ``TimeAwareSymbols``, an extension of a normal Sympy symbol. For a control variable x, the total derivative over time is built up as ``dL[]/dx[] + beta * dL[+1]/dx + beta * beta * dL[+2]/dx[] ...``. This unrolling terminates when ``dL[+n]/dx[] = 0``.
 

--- a/docs/source/user_guide/gcn_files/syntax.rst
+++ b/docs/source/user_guide/gcn_files/syntax.rst
@@ -55,7 +55,8 @@ Here is an example of a GCN file that represents a simple RBC model, found in th
 
         objective
         {
-            TC[] = -(r[] * K[-1] + w[] * L[]);
+            @minimize
+            TC[] = r[] * K[-1] + w[] * L[];
         };
 
         constraints
@@ -180,16 +181,21 @@ In the above example, there are two examples of objectives. The household seeks 
 
 In the mathematical notation above, this was written with an infinite sum. These sums cannot be represented in the GCN file, so the user must first convert the sum to a recursive Bellman equation. Notice also that the variable ``u[]``, defined in the ``definitions`` block, is used here to shorten the expression.
 
-The firm seeks to minimize total costs. This is represented by the following block:
+The firm seeks to minimize total costs. This can be written using the ``@minimize`` tag:
 
 .. code-block:: bash
 
     objective
     {
-        TC[] = -(r[] * K[-1] + w[] * L[]);
+        @minimize
+        TC[] = r[] * K[-1] + w[] * L[];
     };
 
-In gEconpy, all objectives must be written as *maximization* problems. Since the firm is minimizing costs, the objective function is written with a minus sign.
+The ``@minimize`` tag tells gEconpy to treat the objective as a minimization problem. Internally, the objective is negated before forming the Lagrangian, so the resulting first-order conditions are those of the corresponding minimization program. The default behavior (when no tag is present) is maximization. An explicit ``@maximize`` tag is also available for clarity, but is not required.
+
+.. note::
+    You could also write a minimization by manually negating the objective: ``TC[] = -(r[] * K[-1] + w[] * L[])``.
+    Be aware that this will result in a negative steady-state value for the ``TC[]`` variable, which has implication for log-linearization. That is, you can't log linearize it, because it's negative.
 
 
 Constraints
@@ -347,6 +353,8 @@ The multiplier associated with the budget constraint has been given the name "la
 
 Internally, first order conditions are solved by first making all substitutions from ``definitions``, then forming the following Lagrangian function:
 ``L = objective.RHS - lm1 * (control_1.LHS - control_1.RHS) - lm2 * (control_2.LHS - control_2.RHS) ... - lm_k * (control_k.LHS - control_k.RHS)``
+
+When the objective carries the ``@minimize`` tag, the objective RHS is negated before forming the Lagrangian, converting the minimization into an equivalent maximization.
 
 Next, the derivative of this Lagrangian is taken with respect to all control variables and all lagrange multipliers. Derivaties are are computed "though time" using ``TimeAwareSymbols``, an extension of a normal Sympy symbol. For a control variable x, the total derivative over time is built up as ``dL[]/dx[] + beta * dL[+1]/dx + beta * beta * dL[+2]/dx[] ...``. This unrolling terminates when ``dL[+n]/dx[] = 0``.
 

--- a/gEconpy/model/block.py
+++ b/gEconpy/model/block.py
@@ -247,9 +247,12 @@ class Block:
         # Validate equation flags
         # - the "is_calibrating" key can only occur in the calibration block
         # - the "exclude" key can only occur in the constraints block
+        # - the "minimize" and "maximize" keys can only occur in the objective block
         valid_flags = {
             "is_calibrating": ["calibration"],
             "exclude": ["constraints"],
+            "minimize": ["objective"],
+            "maximize": ["objective"],
         }
 
         for name, eq_block in zip(
@@ -272,6 +275,25 @@ class Block:
                             f"Equation {eq} in {name} block of {self.name} has an invalid decorator: exclude. "
                             f"This flag should only appear in the constraints block."
                         )
+                    if self.equation_flags[key].get("minimize", False) and name not in valid_flags["minimize"]:
+                        raise ValueError(
+                            f"Equation {eq} in {name} block of {self.name} has an invalid decorator: minimize. "
+                            f"This flag should only appear in the objective block."
+                        )
+                    if self.equation_flags[key].get("maximize", False) and name not in valid_flags["maximize"]:
+                        raise ValueError(
+                            f"Equation {eq} in {name} block of {self.name} has an invalid decorator: maximize. "
+                            f"This flag should only appear in the objective block."
+                        )
+
+        # Check mutual exclusivity of @minimize and @maximize
+        if self.objective is not None:
+            for key in self.objective:
+                flags = self.equation_flags[key]
+                if flags.get("minimize", False) and flags.get("maximize", False):
+                    raise ValueError(
+                        f"Objective equation in block {self.name} has both @minimize and @maximize tags. Use only one."
+                    )
 
         return True
 
@@ -501,6 +523,9 @@ class Block:
     def _build_lagrangian(self) -> sp.Add:
         """Build the Lagrangian associated with the block's optimization program."""
         objective = next(iter(self.objective.values()))
+        obj_key = next(iter(self.objective.keys()))
+        is_minimization = self.equation_flags[obj_key].get("minimize", False)
+
         constraints = self.constraints
         multipliers = self.multipliers
         sub_dict = {}
@@ -512,7 +537,11 @@ class Block:
 
         i = 1
 
-        lagrange = objective.rhs.subs(sub_dict)
+        obj_rhs = objective.rhs.subs(sub_dict)
+        if is_minimization:
+            obj_rhs = -obj_rhs
+
+        lagrange = obj_rhs
         for key, constraint in constraints.items():
             if multipliers[key] is not None:
                 lm = multipliers[key]
@@ -638,6 +667,10 @@ class Block:
             \text{constraint}_n
 
         And taking the derivative with respect to each control variable in turn.
+
+        When the objective equation carries the ``@minimize`` tag, the objective is automatically negated before
+        forming the Lagrangian (i.e. ``minimize f`` is converted to ``maximize -f``). The resulting first-order
+        conditions are those of the corresponding minimization program.
 
         Parameters
         ----------

--- a/gEconpy/parser/ast/nodes.py
+++ b/gEconpy/parser/ast/nodes.py
@@ -112,6 +112,8 @@ class Tag(Enum):
     """
 
     EXCLUDE = "exclude"  # Exclude equation from final system after optimization
+    MINIMIZE = "minimize"  # Treat objective as a minimization problem
+    MAXIMIZE = "maximize"  # Explicitly mark objective as maximization (default)
 
     @classmethod
     def from_string(cls, name: str) -> Tag:
@@ -307,13 +309,19 @@ class GCNEquation(Node):
         )
 
     def has_tag(self, tag: Tag) -> bool:
-        """Check if the equation has a specific tag."""
         return tag in self.tags
 
     @property
     def is_excluded(self) -> bool:
-        """Check if the equation has the @exclude tag."""
         return Tag.EXCLUDE in self.tags
+
+    @property
+    def is_minimize(self) -> bool:
+        return Tag.MINIMIZE in self.tags
+
+    @property
+    def is_maximize(self) -> bool:
+        return Tag.MAXIMIZE in self.tags
 
     @property
     def is_calibrating(self) -> bool:

--- a/gEconpy/parser/grammar/statements.py
+++ b/gEconpy/parser/grammar/statements.py
@@ -70,7 +70,7 @@ VARIABLE_REF = (
 
 VARIABLE_LIST = pp.DelimitedList(VARIABLE_REF)
 
-VALID_TAGS = frozenset(["exclude"])
+VALID_TAGS = frozenset(["exclude", "minimize", "maximize"])
 
 
 def _parse_tag(s: str, loc: int, toks):

--- a/gEconpy/parser/transform/to_block.py
+++ b/gEconpy/parser/transform/to_block.py
@@ -60,6 +60,10 @@ def _extract_flags(eq: GCNEquation) -> dict[str, bool]:
     flags = {}
     if eq.has_tag(Tag.EXCLUDE):
         flags["exclude"] = True
+    if eq.has_tag(Tag.MINIMIZE):
+        flags["minimize"] = True
+    if eq.has_tag(Tag.MAXIMIZE):
+        flags["maximize"] = True
     if eq.calibrating_parameter:
         flags["is_calibrating"] = True
     else:

--- a/tests/_resources/test_gcns/rbc_2_block_minimize.gcn
+++ b/tests/_resources/test_gcns/rbc_2_block_minimize.gcn
@@ -1,0 +1,74 @@
+options
+{
+    output logfile = TRUE;
+    output LaTeX = TRUE;
+    output LaTeX landscape = TRUE;
+};
+
+
+block HOUSEHOLD
+{
+    definitions
+    {
+		u[] = C[] ^ (1 - sigma_C) / (1 - sigma_C) -
+			  L[] ^ (1 + sigma_L) / (1 + sigma_L);
+    };
+    controls
+    {
+		K[], C[], L[], I[];
+    };
+    objective
+    {
+		U[] = u[] + beta * E[][U[1]];
+    };
+    constraints
+    {
+		C[] + I[] = w[] * L[] + r[] * K[-1] : lambda[];
+		K[] = (1 - delta) * K[-1] + I[] : q[];
+    };
+
+    calibration
+    {
+		beta = 0.985;
+		delta = 0.025;
+		sigma_C = 2;
+		sigma_L = 1.5;
+    };
+};
+
+
+block FIRM
+{
+	controls
+	{
+		K[-1], L[];
+	};
+
+    objective
+    {
+		@minimize
+		TC[] = w[] * L[] + r[] * K[-1];
+    };
+
+    constraints
+    {
+		Y[] = A[] * K[-1] ^ alpha * L[] ^ (1 - alpha) : P[];
+    };
+
+	identities
+	{
+		log(A[]) = rho_A * log(A[-1]) + epsilon_A[];
+		P[] = 1;
+	};
+
+	shocks
+	{
+		epsilon_A[];
+	};
+
+    calibration
+    {
+		alpha = 0.35;
+		rho_A = 0.95;
+    };
+};

--- a/tests/model/test_block.py
+++ b/tests/model/test_block.py
@@ -696,3 +696,87 @@ def test_ss_variable_in_calibration_resolves_to_deterministic_param():
 
     assert phi in block.deterministic_dict
     assert block.deterministic_dict[phi] == Y_bar**2 + alpha
+
+
+def test_minimize_tag_produces_correct_firm_focs(rng):
+    """The @minimize tag on a cost-minimization objective should yield the same FOCs as manual negation."""
+    result = load_gcn_file(ROOT / "_resources" / "test_gcns" / "rbc_2_block_minimize.gcn")
+    firm_block = result.block_dict["FIRM"]
+
+    Y = TimeAwareSymbol("Y", 0)
+    TC = TimeAwareSymbol("TC", 0)
+    K = TimeAwareSymbol("K", -1)
+    L = TimeAwareSymbol("L", 0)
+    A = TimeAwareSymbol("A", 0)
+    r = TimeAwareSymbol("r", 0)
+    w = TimeAwareSymbol("w", 0)
+    P = TimeAwareSymbol("P", 0)
+    epsilon = TimeAwareSymbol("epsilon_A", 0)
+    alpha, rho = sp.symbols(["alpha", "rho_A"])
+
+    all_variables = [Y, TC, K, L, A, A.step_backward(), P, r, w, alpha, rho, epsilon]
+    sub_dict = dict(zip(all_variables, rng.uniform(0.1, 1, size=len(all_variables)), strict=False))
+
+    # Hand-derived FOCs for min_{K,L} (r*K + w*L) s.t. Y = A*K^alpha*L^(1-alpha) : P
+    expected_dL_dK = -r + P * A * alpha * K ** (alpha - 1) * L ** (1 - alpha)
+    expected_dL_dL = -w + P * A * (1 - alpha) * K**alpha * L ** (-alpha)
+
+    subbed_system = [eq.subs(sub_dict) for eq in firm_block.system_equations]
+
+    for expected_foc in [expected_dL_dK, expected_dL_dL]:
+        assert expected_foc.subs(sub_dict) in subbed_system
+
+
+def test_minimize_and_maximize_on_same_equation_raises():
+    gcn = """
+    block FIRM
+    {
+        controls { L[]; };
+        objective
+        {
+            @minimize
+            @maximize
+            TC[] = w[] * L[];
+        };
+        constraints { Y[] = A[] * L[] : mc[]; };
+    };
+    """
+    with pytest.raises(ValueError, match="both @minimize and @maximize"):
+        load_gcn_string(gcn)
+
+
+_CONSTRAINT_BLOCK = """
+    block B
+    {{
+        controls {{ C[]; }};
+        objective {{ U[] = C[]; }};
+        constraints {{ @{tag} C[] = 1 : lambda[]; }};
+    }};
+"""
+
+_IDENTITY_BLOCK = """
+    block B
+    {{
+        identities {{ @{tag} Y[] = C[]; }};
+    }};
+"""
+
+
+@pytest.mark.parametrize(
+    "tag, gcn_template",
+    [
+        ("minimize", _CONSTRAINT_BLOCK),
+        ("minimize", _IDENTITY_BLOCK),
+        ("maximize", _CONSTRAINT_BLOCK),
+        ("maximize", _IDENTITY_BLOCK),
+    ],
+    ids=[
+        "minimize-on-constraint",
+        "minimize-on-identity",
+        "maximize-on-constraint",
+        "maximize-on-identity",
+    ],
+)
+def test_optimization_tag_on_wrong_component_raises(tag, gcn_template):
+    with pytest.raises(ValueError, match=f"invalid decorator: {tag}"):
+        load_gcn_string(gcn_template.format(tag=tag))


### PR DESCRIPTION
Currently, all optimizaiton problems defined in a block are maximization problems. To get minimization, one has to meanually negate the objective. This leads to awkward signs. For example the firm's total cost varible will be negative, so the steady-state can't be easily log-linearized, and dividends to the household look lik `dividend = sales + total_cost`, which is weird.

Solution: Add a `@minimize` tag on objective functions that want minimization. `@maximize` is also added, but this is the assumed default (still, its nice for writing self-documenting code)

<!-- readthedocs-preview gEconpy start -->
----
📚 Documentation preview 📚: https://gEconpy--87.org.readthedocs.build/en/87/

<!-- readthedocs-preview gEconpy end -->