### PR TITLE
Reduce model compile time with pytensor flag tuning and graph pruning

### DIFF
--- a/gEconpy/__init__.py
+++ b/gEconpy/__init__.py
@@ -1,6 +1,31 @@
 import logging as _logging
+import os as _os
 
 from importlib.metadata import version as _version
+
+# Set PYTENSOR_FLAGS for users who import gEconpy before pytensor, then force-set on the live config so the
+# settings also win when pytensor is already loaded (e.g. ``import pymc`` first). Users can override via their
+# own PYTENSOR_FLAGS.
+_existing_flags = _os.environ.get("PYTENSOR_FLAGS", "")
+if "optimizer_excluding" not in _existing_flags:
+    _excludes = ":".join(
+        [
+            "local_mul_zero",
+            "local_greedy_distributor",
+            "local_upcast_elemwise_constant_inputs",
+            "local_neg_to_mul",
+        ]
+    )
+    _new_flag = f"optimizer_excluding={_excludes}"
+    _os.environ["PYTENSOR_FLAGS"] = f"{_existing_flags},{_new_flag}".lstrip(",")
+if "traceback__limit" not in _existing_flags:
+    _os.environ["PYTENSOR_FLAGS"] = f"{_os.environ['PYTENSOR_FLAGS']},traceback__limit=0".lstrip(",")
+
+import pytensor as _pytensor
+
+_pytensor.config.traceback__limit = 0
+# optimizer_excluding can't be appended on the live config; only the env-var-driven init honors it. The
+# traceback flag matters most for grad/compile speed and IS settable live, so set it unconditionally.
 
 # Side-effect imports: register JAX and Numba dispatch rules for internal
 # pytensor Ops. These modules expose no public API.

--- a/gEconpy/model/build.py
+++ b/gEconpy/model/build.py
@@ -4,6 +4,7 @@ import sys
 from pathlib import Path
 from warnings import warn
 
+import pytensor.tensor as pt
 import sympy as sp
 
 from pytensor.graph.replace import graph_replace
@@ -12,7 +13,6 @@ from gEconpy.classes.containers import SymbolDictionary
 from gEconpy.classes.distributions import CompositeDistribution
 from gEconpy.classes.time_aware_symbol import TimeAwareSymbol
 from gEconpy.exceptions import ExtraParameterError, ExtraParameterWarning, OrphanParameterError
-from gEconpy.model.compile import make_cache_key
 from gEconpy.model.model import Model
 from gEconpy.model.parameters import compile_param_dict_func
 from gEconpy.model.perturbation import linearize_model as _linearize_model
@@ -21,8 +21,6 @@ from gEconpy.model.statespace import DSGEStateSpace
 from gEconpy.model.steady_state import (
     ERROR_FUNCTIONS,
     _ss_residual_to_pytensor,
-    build_minimize_graphs,
-    build_root_graphs,
     compile_known_ss,
     propagate_steady_state_through_identities,
     simplify_provided_ss_equations,
@@ -573,11 +571,11 @@ def statespace_from_gcn(
     simplify_constants: bool = True,
     infer_steady_state: bool = True,
     verbose: bool = True,
-    error_function: ERROR_FUNCTIONS = "squared",
     on_unused_parameters: str = "raise",
     log_linearize: bool = True,
     not_loglin_variables: list[str] | None = None,
     show_errors: bool = True,
+    filter_type: str = "standard",
 ) -> DSGEStateSpace:
     """
     Build a symbolic DSGE state-space model from a GCN file.
@@ -600,8 +598,6 @@ def statespace_from_gcn(
         Propagate analytical steady-state solutions through identities.
     verbose : bool, default True
         Print a build report on completion.
-    error_function : str, default ``'squared'``
-        Steady-state error function.
     on_unused_parameters : str, default ``'raise'``
         How to handle unused parameters: ``'raise'``, ``'warn'``, or ``'ignore'``.
     log_linearize : bool, default True
@@ -610,6 +606,8 @@ def statespace_from_gcn(
         Variable names to exclude from log-linearization.
     show_errors : bool, default True
         Pretty-print parse errors to stderr.
+    filter_type : str, default ``'standard'``
+        Kalman-filter variant to use in the underlying ``PyMCStateSpace``.
 
     Returns
     -------
@@ -671,22 +669,10 @@ def statespace_from_gcn(
         cache=cache,
     )
 
-    ss_variables = [x.to_ss() for x in variables]
-    ss_nodes = []
-    for v in ss_variables:
-        ck = make_cache_key(v.name, type(v))
-        if ck in cache:
-            ss_nodes.append(cache[ck])
-
-    ss_resid, ss_jac = build_root_graphs(equations_pt, ss_nodes, use_jac=True)
-    ss_error, ss_grad, ss_hess, _, _ = build_minimize_graphs(
-        equations_pt,
-        ss_nodes,
-        error_func=error_function,
-        use_jac=True,
-        use_hess=True,
-        use_hessp=False,
-    )
+    # DSGEStateSpace only consumes ss_resid (squared into a penalty in _setup_ss_model).
+    # The Jacobian / error / gradient / Hessian graphs that the model_from_gcn path needs
+    # for numerical SS solving are discarded here, so don't build them.
+    ss_resid = pt.stack(equations_pt) if equations_pt else pt.zeros(0)
 
     if not_loglin_variables is None:
         not_loglin_variables = []
@@ -718,11 +704,7 @@ def statespace_from_gcn(
     }
     replacements = parameter_mapping | steady_state_mapping
 
-    ss_resid, ss_jac, ss_error, ss_grad, ss_hess = graph_replace(
-        [ss_resid, ss_jac, ss_error, ss_grad, ss_hess],
-        replacements,
-        strict=False,
-    )
+    ss_resid = graph_replace(ss_resid, replacements, strict=False)
     A, B, C, D = rewrite_pregrad(graph_replace([A, B, C, D], replacements, strict=False))
 
     return DSGEStateSpace(
@@ -735,12 +717,9 @@ def statespace_from_gcn(
         shock_priors=shock_priors,
         parameter_mapping=parameter_mapping,
         steady_state_mapping=steady_state_mapping,
-        ss_jac=ss_jac,
         ss_resid=ss_resid,
-        ss_error=ss_error,
-        ss_error_grad=ss_grad,
-        ss_error_hess=ss_hess,
         linearized_system=[A, B, C, D],
+        filter_type=filter_type,
         verbose=verbose,
     )
 

--- a/gEconpy/model/statespace.py
+++ b/gEconpy/model/statespace.py
@@ -53,12 +53,9 @@ class DSGEStateSpace(PyMCStateSpace):
         shock_priors: SymbolDictionary[str, CompositeDistribution],
         parameter_mapping: dict[pt.TensorVariable, pt.TensorVariable],
         steady_state_mapping: dict[pt.TensorVariable, pt.TensorVariable],
-        ss_jac: pt.TensorVariable,
         ss_resid: pt.TensorVariable,
-        ss_error: pt.TensorVariable,
-        ss_error_grad: pt.TensorVariable,
-        ss_error_hess: pt.TensorVariable,
         linearized_system: list[pt.TensorVariable],
+        filter_type: str = "standard",
         verbose: bool = True,
     ):
         """
@@ -88,16 +85,9 @@ class DSGEStateSpace(PyMCStateSpace):
             deterministic.
         steady_state_mapping: dict
             Symbolic function mapping input parameters to the steady state values of the model
-        ss_jac: pt.TensorVariable
-            Symbolic Jacobian of the steady state equations
         ss_resid: pt.TensorVariable
-            Symbolic vector of (signed) residuals of the steady state equations
-        ss_error: pt.TensorVariable
-            Symbolic scalar-valued error function used to minimize the steady state residuals.
-        ss_error_grad: pt.TensorVariable
-            Symbolic gradient of the steady state error function
-        ss_error_hess: pt.TensorVariable
-            Symbolic hessian of the steady state error function
+            Symbolic vector of (signed) residuals of the steady state equations. Used as a penalty term
+            during PyMC sampling to flag parameter draws whose analytical SS does not satisfy the FOCs.
         linearized_system: list of pt.TensorVariable
             List of four symbolic expressions representing the linearized system of equations as partial
             jacobians of the model equations with respect to variables at time t+1 (A), t (B), t-1 (C), and with
@@ -117,11 +107,7 @@ class DSGEStateSpace(PyMCStateSpace):
         self.steady_state_mapping = steady_state_mapping
         self.input_parameters = [x for x in parameter_mapping if x.name in param_dict]
 
-        self.ss_jac = ss_jac
         self.ss_resid = ss_resid
-        self.ss_error = ss_error
-        self.ss_error_grad = ss_error_grad
-        self.ss_error_hess = ss_error_hess
 
         self.linearized_system = linearized_system
 
@@ -157,7 +143,7 @@ class DSGEStateSpace(PyMCStateSpace):
             k_endog,
             k_states,
             k_posdef,
-            filter_type="standard",
+            filter_type=filter_type,
             verbose=False,
             measurement_error=False,
         )

--- a/gEconpy/pytensorf/compile.py
+++ b/gEconpy/pytensorf/compile.py
@@ -9,6 +9,7 @@ from pytensor.tensor.variable import TensorVariable
 
 
 def rewrite_pregrad(graph):
+    """Run canonicalize + stabilize on a graph before gradient propagation."""
     return rewrite_graph(graph, include=("canonicalize", "stabilize"))
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,6 +196,10 @@ max-complexity = 10
 lines-between-types = 1
 
 [tool.ruff.lint.per-file-ignores]
+'gEconpy/__init__.py' = [
+    "E402", # Must set PYTENSOR_FLAGS before importing pytensor
+]
+
 'benchmarks/*.py' = [
     "PLC0415", # Allow imports inside the setup method of asv benchmarks
     "ARG002", # Allow unused arguments in asv benchmark setup methods


### PR DESCRIPTION
Exclude costly scalar rewrites via global PYTENSOR_FLAGS on gEconpy import:
- local_mul_zero
- local_greedy_distributor 
- local_upcast_elemwise_constant_inputs"
- local_neg_to_mul

Instead rely on sympy to clean these up for us.

- Don't track traceback for deep graphs
- statespace_from_gcn skips compiling expensive steady-state graphs

<!-- readthedocs-preview gEconpy start -->
----
📚 Documentation preview 📚: https://gEconpy--92.org.readthedocs.build/en/92/

<!-- readthedocs-preview gEconpy end -->