### PR TITLE
Miscellaneous bug fixes

### DIFF
--- a/gEconpy/solvers/cycle_reduction.py
+++ b/gEconpy/solvers/cycle_reduction.py
@@ -9,6 +9,7 @@ from pytensor.graph import Apply, Op
 from pytensor.link.numba.dispatch import basic as numba_basic
 from pytensor.link.numba.dispatch.basic import register_funcify_default_op_cache_key
 from pytensor.link.numba.dispatch.linalg.decomposition.lu_factor import _lu_factor
+from pytensor.link.numba.dispatch.linalg.solvers.general import _solve_gen
 from pytensor.link.numba.dispatch.linalg.solvers.lu_solve import _getrs
 
 from gEconpy.model.perturbation import _log
@@ -200,7 +201,13 @@ def _cycle_reduction_core(
         elif np.isnan(A0_L1_norm):
             break
 
-    T = -np.linalg.solve(A1_hat, A0_initial) if converged else np.zeros_like(A0_initial)
+    # ``_solve_gen`` returns NaN-filled output on LAPACK INFO error instead of
+    # raising — lets the sampler reject the draw rather than abort the run.
+    if converged:
+        X = _solve_gen(A1_hat, A0_initial, False, False, False, False)
+        T = -X
+    else:
+        T = np.zeros_like(A0_initial)
 
     return T, converged
 

--- a/gEconpy/utilities.py
+++ b/gEconpy/utilities.py
@@ -83,16 +83,39 @@ def step_equation_backward(eq):
 
 
 def diff_through_time(eq, dx, discount_factor=1):
-    total_dydx = 0
-    next_dydx = 1
+    r"""Differentiate an equation with respect to a time-aware symbol, summing across time shifts.
 
-    while next_dydx != 0:
-        next_dydx = eq.diff(dx)
+    Computes :math:`\sum_{k=0}^{K} \beta^k \cdot \frac{\partial}{\partial dx} \mathrm{step}^k(\mathrm{eq})` where each
+    step shifts every TimeAwareSymbol's time index forward by one. The number of iterations ``K`` is determined by the
+    spread between ``dx``'s time index and the earliest appearance of ``dx``'s base symbol in ``eq``: stepping forward
+    further can only increase the time indices of all instances, so once the leftmost has shifted past ``dx``, no
+    additional contribution is possible.
+
+    Parameters
+    ----------
+    eq : sympy.Expr
+        Equation (typically a Lagrangian) to differentiate.
+    dx : TimeAwareSymbol
+        Variable to differentiate with respect to.
+    discount_factor : sympy.Expr or int, optional
+        Multiplicative discount factor applied at each forward step. Default 1 (no discounting).
+
+    Returns
+    -------
+    total : sympy.Expr
+        Sum of discounted derivatives across all relevant time shifts.
+    """
+    times_in_eq = {a.time_index for a in eq.atoms(TimeAwareSymbol) if a.base_name == dx.base_name}
+    if not times_in_eq:
+        return sp.S.Zero
+    n_iters = max(0, dx.time_index - min(times_in_eq))
+
+    total = sp.S.Zero
+    for _ in range(n_iters + 1):
+        total += eq.diff(dx)
         eq = step_equation_forward(eq) * discount_factor
         discount_factor = step_equation_forward(discount_factor)
-        total_dydx += next_dydx
-
-    return total_dydx
+    return total
 
 
 def substitute_all_equations(eqs, *sub_dicts):

--- a/tests/classes/test_time_aware_symbol.py
+++ b/tests/classes/test_time_aware_symbol.py
@@ -63,6 +63,36 @@ class TimeAwareSymbolTests(unittest.TestCase):
 
         self.assertEqual(dX_dx_t, sum(sp.Symbol("beta") ** t for t in range(11)))
 
+    def test_diff_through_time_gap_in_time_indices(self):
+        # Regression: when dx's base symbol appears at non-consecutive time indices, the derivative is zero at some
+        # intermediate iterations but nonzero again later. The summation must walk through all relevant shifts, not exit
+        # on the first zero. For eq = x[t] + a*x[t-2] differentiated wrt x[t]:
+        #   k=0: contributes 1 (from x[t])
+        #   k=1: contributes 0 (eq has x[t+1], x[t-1])
+        #   k=2: contributes a*beta**2 (eq has x[t+2], x[t]; the t-2 term has shifted to t)
+        a, beta = sp.symbols("a beta")
+        x_tm2 = TimeAwareSymbol("x", -2)
+        eq = self.x_t + a * x_tm2
+
+        result = diff_through_time(eq, self.x_t, beta)
+        expected = 1 + a * beta**2
+        self.assertEqual(sp.simplify(result - expected), 0)
+
+    def test_diff_through_time_no_appearance(self):
+        # If dx's base symbol doesn't appear in eq, the result is zero — no iterations needed.
+        y_t = TimeAwareSymbol("y", 0)
+        eq = y_t + sp.Symbol("c")
+        result = diff_through_time(eq, self.x_t, sp.Symbol("beta"))
+        self.assertEqual(result, 0)
+
+    def test_diff_through_time_only_forward_appearances(self):
+        # If dx's base symbol appears only at time indices >= dx.time_index, only iter 0 can contribute (forward
+        # stepping pushes everything further from dx). Confirm we don't iterate spuriously.
+        x_tp3 = TimeAwareSymbol("x", 3)
+        eq = self.x_t + sp.Symbol("a") * x_tp3
+        result = diff_through_time(eq, self.x_t, sp.Symbol("beta"))
+        self.assertEqual(result, 1)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
- diff_through_time does the right thing when the objective has non-contiguous time indices
- Return NaN instead of raising on singular cycle reduction solve

<!-- readthedocs-preview gEconpy start -->
----
📚 Documentation preview 📚: https://gEconpy--93.org.readthedocs.build/en/93/

<!-- readthedocs-preview gEconpy end -->