### PR TITLE
Set default assumptions for all symbols

### DIFF
--- a/gEconpy/classes/time_aware_symbol.py
+++ b/gEconpy/classes/time_aware_symbol.py
@@ -2,6 +2,19 @@ import sympy as sp
 
 from sympy.core.cache import cacheit
 
+# Domain defaults injected into every parsed Symbol unless the user's ``assumptions`` block overrides them.
+# ``real``: every DSGE quantity (variable, parameter, shock, multiplier) is real-valued. ``finite``: every DSGE
+# quantity is finite — no extended-real ±infinity. Together these give sympy enough type information to apply many
+# simplifications it would otherwise refuse on bare Symbols. ``positive``, ``nonzero``, ``integer`` are intentionally
+# NOT defaulted: those are domain-specific (e.g. Lagrange multipliers can be negative, shocks are zero in steady
+# state) and stay opt-in via the ``assumptions`` block.
+DEFAULT_ASSUMPTIONS: dict[str, bool] = {"real": True, "finite": True}
+
+
+def merge_assumptions(user_assumptions: dict[str, bool] | None) -> dict[str, bool]:
+    """Merge :data:`DEFAULT_ASSUMPTIONS` with user-declared assumptions; user values win on conflict."""
+    return {**DEFAULT_ASSUMPTIONS, **(user_assumptions or {})}
+
 
 class TimeAwareSymbol(sp.Symbol):
     """

--- a/gEconpy/model/block/basic.py
+++ b/gEconpy/model/block/basic.py
@@ -1,7 +1,7 @@
 import sympy as sp
 
 from gEconpy.classes.containers import SymbolDictionary
-from gEconpy.classes.time_aware_symbol import TimeAwareSymbol
+from gEconpy.classes.time_aware_symbol import DEFAULT_ASSUMPTIONS, TimeAwareSymbol
 from gEconpy.exceptions import (
     ControlVariableNotFoundException,
     DuplicateParameterError,
@@ -542,7 +542,7 @@ class Block:
             if multipliers[key] is not None:
                 lm = multipliers[key]
             else:
-                lm = TimeAwareSymbol(f"lambda__{self.short_name}_{i}", 0)
+                lm = TimeAwareSymbol(f"lambda__{self.short_name}_{i}", 0, **DEFAULT_ASSUMPTIONS)
                 self.multipliers[i] = lm
                 i += 1
 

--- a/gEconpy/parser/loader.py
+++ b/gEconpy/parser/loader.py
@@ -14,7 +14,7 @@ from gEconpy.parser.constants import STEADY_STATE_NAMES
 from gEconpy.parser.preprocessor import preprocess, preprocess_file
 from gEconpy.parser.transform.to_block import ast_model_to_block_dict
 from gEconpy.parser.transform.to_distribution import ast_to_distribution_with_metadata
-from gEconpy.parser.transform.to_sympy import ast_to_sympy, equation_to_sympy
+from gEconpy.parser.transform.to_sympy import ast_to_sympy, equation_to_sympy, merge_assumptions
 from gEconpy.utilities import flatten_substitution_dict
 
 PARAM_DICTS = Literal["param_dict", "deterministic_dict", "calib_dict"]
@@ -231,7 +231,7 @@ def ast_block_to_calibration(
             if item.is_calibrating:
                 # Calibrating equation: param = expr -> 0
                 # Create parameter symbol with appropriate assumptions
-                param_assumptions = assumptions.get(item.calibrating_parameter, {})
+                param_assumptions = merge_assumptions(assumptions.get(item.calibrating_parameter))
                 calib_param = sp.Symbol(item.calibrating_parameter, **param_assumptions)
                 calib_dict[calib_param] = sp.Eq(lhs_sympy, rhs_sympy)
             # Simple assignment: param = value

--- a/gEconpy/parser/transform/to_block.py
+++ b/gEconpy/parser/transform/to_block.py
@@ -12,7 +12,7 @@ from gEconpy.parser.ast import (
     Tag,
 )
 from gEconpy.parser.transform.expand_time_indices import expand_block_time_indices
-from gEconpy.parser.transform.to_sympy import ast_to_sympy
+from gEconpy.parser.transform.to_sympy import ast_to_sympy, merge_assumptions
 
 
 def _equation_to_sympy(
@@ -27,7 +27,7 @@ def _equation_to_sympy(
     # For calibrating equations with `-> param`, rewrite as `Eq(param, rhs - lhs)`
     # This matches what Block._get_param_dict_and_calibrating_equations expects
     if eq.calibrating_parameter:
-        param_assumptions = assumptions.get(eq.calibrating_parameter, {})
+        param_assumptions = merge_assumptions(assumptions.get(eq.calibrating_parameter))
         param = sp.Symbol(eq.calibrating_parameter, **param_assumptions)
         # The calibrating equation form is: original_lhs = original_rhs -> param
         # Block expects: param = original_rhs - original_lhs (as equation to solve)
@@ -72,7 +72,7 @@ def _extract_multiplier(
         return None
     assumptions = assumptions or {}
     name = eq.lagrange_multiplier
-    var_assumptions = assumptions.get(name, {})
+    var_assumptions = merge_assumptions(assumptions.get(name))
     return TimeAwareSymbol(name, 0, **var_assumptions)
 
 
@@ -220,7 +220,7 @@ def _convert_calibration(
                 param_locations[item.lhs.name] = item.location
         elif isinstance(item, GCNDistribution):
             if item.initial_value is not None:
-                param_assumptions = assumptions.get(item.parameter_name, {})
+                param_assumptions = merge_assumptions(assumptions.get(item.parameter_name))
                 param = sp.Symbol(item.parameter_name, **param_assumptions)
                 value = sp.Float(item.initial_value)
                 calib_items.append((None, sp.Eq(param, value)))

--- a/gEconpy/parser/transform/to_sympy.py
+++ b/gEconpy/parser/transform/to_sympy.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import sympy as sp
 
-from gEconpy.classes.time_aware_symbol import TimeAwareSymbol
+from gEconpy.classes.time_aware_symbol import TimeAwareSymbol, merge_assumptions
 from gEconpy.parser.ast import (
     BinaryOp,
     Expectation,
@@ -102,11 +102,11 @@ class ASTToSympyConverter:
         return sp.Float(node.value)
 
     def _convert_parameter(self, node: Parameter) -> sp.Symbol:
-        assumptions = self.assumptions.get(node.name, {})
+        assumptions = merge_assumptions(self.assumptions.get(node.name))
         return sp.Symbol(node.name, **assumptions)
 
     def _convert_variable(self, node: Variable) -> TimeAwareSymbol:
-        assumptions = self.assumptions.get(node.name, {})
+        assumptions = merge_assumptions(self.assumptions.get(node.name))
         time_index = node.time_index
 
         if time_index.is_steady_state:
@@ -194,13 +194,13 @@ def equation_to_sympy(
     }
 
     if eq.is_calibrating and eq.calibrating_parameter:
-        param_assumptions = (assumptions or {}).get(eq.calibrating_parameter, {})
+        param_assumptions = merge_assumptions((assumptions or {}).get(eq.calibrating_parameter))
         metadata["calibrating_parameter"] = sp.Symbol(eq.calibrating_parameter, **param_assumptions)
         # For calibrating equations, rearrange to: param = lhs - rhs
         sympy_eq = sp.Eq(metadata["calibrating_parameter"], sympy_eq.lhs - sympy_eq.rhs)
 
     if eq.lagrange_multiplier:
-        mult_assumptions = (assumptions or {}).get(eq.lagrange_multiplier, {})
+        mult_assumptions = merge_assumptions((assumptions or {}).get(eq.lagrange_multiplier))
         metadata["lagrange_multiplier"] = TimeAwareSymbol(eq.lagrange_multiplier, 0, **mult_assumptions)
 
     return sympy_eq, metadata

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,30 @@
 from pathlib import Path
 
+import sympy as sp
+
+from gEconpy.classes.time_aware_symbol import DEFAULT_ASSUMPTIONS, TimeAwareSymbol
+
 PROJECT_ROOT = next(p for p in Path(__file__).resolve().parents if (p / "pyproject.toml").exists())
 TESTS_ROOT = PROJECT_ROOT / "tests"
 RESOURCES = TESTS_ROOT / "_resources"
 TEST_GCNS = RESOURCES / "test_gcns"
 ERROR_GCNS = RESOURCES / "error_gcns"
+
+
+def parsed_symbol(name: str, **extra) -> sp.Symbol:
+    """Construct a Symbol matching the parser's defaults (``real=True, finite=True``).
+
+    Use in test fixtures that compare against ``ast_to_sympy`` output. ``sp.Symbol("x") != sp.Symbol("x", real=True)``
+    in sympy's view, so hand-constructed expected Symbols must carry the same assumptions the parser injects.
+    """
+    return sp.Symbol(name, **{**DEFAULT_ASSUMPTIONS, **extra})
+
+
+def parsed_var(name: str, t, **extra) -> TimeAwareSymbol:
+    """Construct a TimeAwareSymbol matching the parser's defaults (``real=True, finite=True``)."""
+    return TimeAwareSymbol(name, t, **{**DEFAULT_ASSUMPTIONS, **extra})
+
+
+def parsed_symbols(names, **extra):
+    """Plural form of :func:`parsed_symbol`, mirroring :func:`sympy.symbols`. ``names`` is a string or list."""
+    return sp.symbols(names, **{**DEFAULT_ASSUMPTIONS, **extra})

--- a/tests/model/block/test_basic.py
+++ b/tests/model/block/test_basic.py
@@ -18,7 +18,7 @@ from gEconpy.parser.loader import load_gcn_file, load_gcn_string
 from gEconpy.parser.preprocessor import preprocess
 from gEconpy.parser.transform.to_block import ast_block_to_block
 from gEconpy.utilities import set_equality_equals_zero, unpack_keys_and_values
-from tests.conftest import TEST_GCNS
+from tests.conftest import TEST_GCNS, parsed_symbol, parsed_symbols, parsed_var
 
 
 def get_block_from_string(gcn_string: str, block_name: str = "HOUSEHOLD") -> Block:
@@ -262,53 +262,53 @@ class TestBlockCases:
     def test_lagrange_parsing(self, block):
         n_nones = [0 if x is None else 1 for x in list(block.multipliers.values())]
         assert sum(n_nones) == 2
-        assert block.multipliers[3] == TimeAwareSymbol("lambda", 0)
-        assert block.multipliers[4] == TimeAwareSymbol("q", 0)
+        assert block.multipliers[3] == parsed_var("lambda", 0)
+        assert block.multipliers[4] == parsed_var("q", 0)
 
     def test_extract_discount_factor_on_Bellman_eq(self, block):
         df = block._get_discount_factor()
         assert df.name == "beta"
 
     def test_extract_discount_factor_on_static_eq(self, block):
-        PI = TimeAwareSymbol("Pi", 0)
-        P = TimeAwareSymbol("P", 0)
-        Y = TimeAwareSymbol("Y", 0)
-        r = TimeAwareSymbol("r", 0)
-        w = TimeAwareSymbol("w", 0)
-        L = TimeAwareSymbol("L", 0)
-        K = TimeAwareSymbol("K", 0)
+        PI = parsed_var("Pi", 0)
+        P = parsed_var("P", 0)
+        Y = parsed_var("Y", 0)
+        r = parsed_var("r", 0)
+        w = parsed_var("w", 0)
+        L = parsed_var("L", 0)
+        K = parsed_var("K", 0)
 
         block.objective = {0: sp.Eq(PI, P * Y - r * K - w * L)}
         df = block._get_discount_factor()
         assert np.allclose(float(df), 1.0)
 
     def test_extract_discount_factor_on_lagged_eq(self, block):
-        PI = TimeAwareSymbol("Pi", 0)
-        P = TimeAwareSymbol("P", 0)
-        Y = TimeAwareSymbol("Y", 0)
-        r = TimeAwareSymbol("r", 0)
-        w = TimeAwareSymbol("w", 0)
-        L = TimeAwareSymbol("L", 0)
-        K = TimeAwareSymbol("K", -1)
+        PI = parsed_var("Pi", 0)
+        P = parsed_var("P", 0)
+        Y = parsed_var("Y", 0)
+        r = parsed_var("r", 0)
+        w = parsed_var("w", 0)
+        L = parsed_var("L", 0)
+        K = parsed_var("K", -1)
 
         block.objective = {0: sp.Eq(PI, P * Y - r * K - w * L)}
         df = block._get_discount_factor()
         assert np.allclose(float(df), 1)
 
     def test_household_lagrangian_function(self, block):
-        U = TimeAwareSymbol("U", 1)
-        Y = TimeAwareSymbol("Y", 0, positive=True)
-        C = TimeAwareSymbol("C", 0, positive=True)
-        I = TimeAwareSymbol("I", 0, positive=True)
-        K = TimeAwareSymbol("K", 0, positive=True)
-        L = TimeAwareSymbol("L", 0, positive=True)
-        A = TimeAwareSymbol("A", 0, positive=True)
-        lamb = TimeAwareSymbol("lambda", 0)
-        lamb_H_1 = TimeAwareSymbol("lambda__H_1", 0)
-        q = TimeAwareSymbol("q", 0)
+        U = parsed_var("U", 1)
+        Y = parsed_var("Y", 0, positive=True)
+        C = parsed_var("C", 0, positive=True)
+        I = parsed_var("I", 0, positive=True)
+        K = parsed_var("K", 0, positive=True)
+        L = parsed_var("L", 0, positive=True)
+        A = parsed_var("A", 0, positive=True)
+        lamb = parsed_var("lambda", 0)
+        lamb_H_1 = parsed_var("lambda__H_1", 0)
+        q = parsed_var("q", 0)
 
-        alpha, beta, delta, theta, tau = sp.symbols(["alpha", "beta", "delta", "theta", "tau"], positive=True)
-        Theta, zeta = sp.symbols(["Theta", "zeta"])
+        alpha, beta, delta, theta, tau = parsed_symbols(["alpha", "beta", "delta", "theta", "tau"], positive=True)
+        Theta, zeta = parsed_symbols(["Theta", "zeta"])
 
         utility = (C**theta * (1 - L) ** (1 - theta)) ** (1 - tau) / (1 - tau)
         mkt_clearing = C + I - Y
@@ -331,22 +331,22 @@ class TestBlockCases:
         assert all(set_equality_equals_zero(eq) in block.system_equations for eq in identities)
         assert objective in block.system_equations
 
-        U = TimeAwareSymbol("U", 1)
-        Y = TimeAwareSymbol("Y", 0, positive=True)
-        C = TimeAwareSymbol("C", 0, positive=True)
-        I = TimeAwareSymbol("I", 0, positive=True)
-        K = TimeAwareSymbol("K", 0, positive=True)
-        L = TimeAwareSymbol("L", 0, positive=True)
-        A = TimeAwareSymbol("A", 0, positive=True)
-        lamb = TimeAwareSymbol("lambda", 0)
-        lamb_H_1 = TimeAwareSymbol("lambda__H_1", 0)
-        q = TimeAwareSymbol("q", 0)
-        eps = TimeAwareSymbol("epsilon", 0)
+        U = parsed_var("U", 1)
+        Y = parsed_var("Y", 0, positive=True)
+        C = parsed_var("C", 0, positive=True)
+        I = parsed_var("I", 0, positive=True)
+        K = parsed_var("K", 0, positive=True)
+        L = parsed_var("L", 0, positive=True)
+        A = parsed_var("A", 0, positive=True)
+        lamb = parsed_var("lambda", 0)
+        lamb_H_1 = parsed_var("lambda__H_1", 0)
+        q = parsed_var("q", 0)
+        eps = parsed_var("epsilon", 0)
 
-        alpha, beta, delta, theta, tau, rho = sp.symbols(
+        alpha, beta, delta, theta, tau, rho = parsed_symbols(
             ["alpha", "beta", "delta", "theta", "tau", "rho"], positive=True
         )
-        Theta, zeta = sp.symbols("Theta, zeta")
+        Theta, zeta = parsed_symbols("Theta, zeta")
 
         all_variables = [
             U,
@@ -395,14 +395,14 @@ class TestBlockCases:
         result = load_gcn_file(TEST_GCNS / "rbc_2_block.gcn")
         block = result.block_dict["FIRM"]
 
-        Y = TimeAwareSymbol("Y", 0)
-        K = TimeAwareSymbol("K", -1)
-        L = TimeAwareSymbol("L", 0)
-        A = TimeAwareSymbol("A", 0)
-        r = TimeAwareSymbol("r", 0)
-        w = TimeAwareSymbol("w", 0)
-        P = TimeAwareSymbol("P", 0)
-        alpha, _rho = sp.symbols(["alpha", "rho"])
+        Y = parsed_var("Y", 0)
+        K = parsed_var("K", -1)
+        L = parsed_var("L", 0)
+        A = parsed_var("A", 0)
+        r = parsed_var("r", 0)
+        w = parsed_var("w", 0)
+        P = parsed_var("P", 0)
+        alpha, _rho = parsed_symbols(["alpha", "rho"])
 
         tc = -(r * K + w * L)
         prod = Y - A * K**alpha * L ** (1 - alpha)
@@ -415,16 +415,16 @@ class TestBlockCases:
         firm_block = result.block_dict["FIRM"]
         firm_block.solve_optimization()
 
-        Y = TimeAwareSymbol("Y", 0)
-        TC = TimeAwareSymbol("TC", 0)
-        K = TimeAwareSymbol("K", -1)
-        L = TimeAwareSymbol("L", 0)
-        A = TimeAwareSymbol("A", 0)
-        r = TimeAwareSymbol("r", 0)
-        w = TimeAwareSymbol("w", 0)
-        P = TimeAwareSymbol("P", 0)
-        epsilon = TimeAwareSymbol("epsilon_A", 0)
-        alpha, rho = sp.symbols(["alpha", "rho_A"])
+        Y = parsed_var("Y", 0)
+        TC = parsed_var("TC", 0)
+        K = parsed_var("K", -1)
+        L = parsed_var("L", 0)
+        A = parsed_var("A", 0)
+        r = parsed_var("r", 0)
+        w = parsed_var("w", 0)
+        P = parsed_var("P", 0)
+        epsilon = parsed_var("epsilon_A", 0)
+        alpha, rho = parsed_symbols(["alpha", "rho_A"])
 
         # Sample random values for all symbols EXCEPT Y, which is set
         # consistently with the production constraint Y = A*K^alpha*L^(1-alpha).
@@ -452,11 +452,11 @@ class TestBlockCases:
     def test_get_param_dict_and_calibrating_equations(self, block):
         block.solve_optimization(try_simplify=False)
 
-        _alpha, theta, beta, delta, tau, rho = sp.symbols(
+        _alpha, theta, beta, delta, tau, rho = parsed_symbols(
             ["alpha", "theta", "beta", "delta", "tau", "rho"], positive=True
         )
-        K = TimeAwareSymbol("K", 0, positive=True).to_ss()
-        L = TimeAwareSymbol("L", 0, positive=True).to_ss()
+        K = parsed_var("K", 0, positive=True).to_ss()
+        L = parsed_var("L", 0, positive=True).to_ss()
 
         answer = {theta: 0.357, beta: 1 / 1.01, delta: 0.02, tau: 2, rho: 0.95}
         assert all(key in block.param_dict for key in answer)
@@ -517,8 +517,8 @@ def test_block_with_exlcuded_equation():
 
 class TestBlockFromSympy:
     def test_from_sympy_creates_valid_block(self):
-        C = TimeAwareSymbol("C", 0)
-        Y = TimeAwareSymbol("Y", 0)
+        C = parsed_var("C", 0)
+        Y = parsed_var("Y", 0)
 
         identities = {0: sp.Eq(Y, C)}
         equation_flags = {0: {}}
@@ -554,12 +554,12 @@ class TestBlockFromSympy:
         loaded_block.solve_optimization()
 
         # Create sympy objects for from_sympy constructor
-        Y = TimeAwareSymbol("Y", 0)
-        C = TimeAwareSymbol("C", 0)
-        I = TimeAwareSymbol("I", 0)
-        K = TimeAwareSymbol("K", 0)
-        K_lag = TimeAwareSymbol("K", -1)
-        delta = sp.Symbol("delta")
+        Y = parsed_var("Y", 0)
+        C = parsed_var("C", 0)
+        I = parsed_var("I", 0)
+        K = parsed_var("K", 0)
+        K_lag = parsed_var("K", -1)
+        delta = parsed_symbol("delta")
 
         identities = {
             0: sp.Eq(Y, C + I),
@@ -589,13 +589,13 @@ class TestBlockFromSympy:
             assert float(loaded_block.param_dict[key]) == float(new_block.param_dict[key])
 
     def test_from_sympy_with_optimization_problem(self):
-        U = TimeAwareSymbol("U", 0)
-        U_next = TimeAwareSymbol("U", 1)
-        C = TimeAwareSymbol("C", 0)
-        L = TimeAwareSymbol("L", 0)
-        w = TimeAwareSymbol("w", 0)
-        lambda_ = TimeAwareSymbol("lambda", 0)
-        beta = sp.Symbol("beta")
+        U = parsed_var("U", 0)
+        U_next = parsed_var("U", 1)
+        C = parsed_var("C", 0)
+        L = parsed_var("L", 0)
+        w = parsed_var("w", 0)
+        lambda_ = parsed_var("lambda", 0)
+        beta = parsed_symbol("beta")
 
         objective = {0: sp.Eq(U, sp.log(C) - L + beta * U_next)}
         constraints = {1: sp.Eq(C, w * L)}
@@ -685,9 +685,9 @@ def test_ss_variable_in_calibration_resolves_to_deterministic_param():
     result = load_gcn_string(gcn)
     block = result.block_dict["HOUSEHOLD"]
 
-    alpha = sp.Symbol("alpha")
-    Y_bar = sp.Symbol("Y_bar")
-    phi = sp.Symbol("phi")
+    alpha = parsed_symbol("alpha")
+    Y_bar = parsed_symbol("Y_bar")
+    phi = parsed_symbol("phi")
 
     assert phi in block.deterministic_dict
     assert block.deterministic_dict[phi] == Y_bar**2 + alpha
@@ -698,16 +698,16 @@ def test_minimize_tag_produces_correct_firm_focs(rng):
     result = load_gcn_file(TEST_GCNS / "rbc_2_block_minimize.gcn")
     firm_block = result.block_dict["FIRM"]
 
-    Y = TimeAwareSymbol("Y", 0)
-    TC = TimeAwareSymbol("TC", 0)
-    K = TimeAwareSymbol("K", -1)
-    L = TimeAwareSymbol("L", 0)
-    A = TimeAwareSymbol("A", 0)
-    r = TimeAwareSymbol("r", 0)
-    w = TimeAwareSymbol("w", 0)
-    P = TimeAwareSymbol("P", 0)
-    epsilon = TimeAwareSymbol("epsilon_A", 0)
-    alpha, rho = sp.symbols(["alpha", "rho_A"])
+    Y = parsed_var("Y", 0)
+    TC = parsed_var("TC", 0)
+    K = parsed_var("K", -1)
+    L = parsed_var("L", 0)
+    A = parsed_var("A", 0)
+    r = parsed_var("r", 0)
+    w = parsed_var("w", 0)
+    P = parsed_var("P", 0)
+    epsilon = parsed_var("epsilon_A", 0)
+    alpha, rho = parsed_symbols(["alpha", "rho_A"])
 
     # Sample Y consistently with the production constraint so the chain-rule
     # and closed-form FOC representations agree numerically. See test_firm_FOC

--- a/tests/parser/transform/test_expectations.py
+++ b/tests/parser/transform/test_expectations.py
@@ -1,0 +1,230 @@
+"""
+Tests documenting that the expectations operator E[][] is currently a no-op.
+
+The expectation operator is stripped during AST-to-sympy conversion (see
+``_convert_expectation`` in ``to_sympy.py``). For first-order perturbation this
+is correct: the solution method implicitly replaces forward-looking variables
+with their conditional expectations via the policy function x_{t+1} = T x_t.
+
+These tests document cases where a proper expectations implementation would
+produce different results, serving as a regression suite for when E[][] is
+eventually given semantic meaning.
+
+Cases where E[][] matters:
+1. Different information sets: E_{t-1}[x_{t+1}] ≠ E_t[x_{t+1}]
+   (predetermined pricing, sticky information models)
+2. Second-order perturbation: E_t[f(x)] ≠ f(E_t[x]) due to Jensen's inequality
+3. Validation: E_t[x_{t-1}] should equal x_{t-1} (known quantity), but there is
+   no check that the argument of E[][] is actually uncertain.
+"""
+
+import numpy as np
+import pytest
+import sympy as sp
+
+from gEconpy.classes.time_aware_symbol import TimeAwareSymbol
+from gEconpy.parser.ast import (
+    T_PLUS_1,
+    BinaryOp,
+    Expectation,
+    Number,
+    Operator,
+    Parameter,
+    T,
+    TimeIndex,
+    Variable,
+)
+from gEconpy.parser.grammar.expressions import parse_expression
+from gEconpy.parser.transform.to_sympy import ast_to_sympy
+from tests.conftest import parsed_symbol, parsed_symbols, parsed_var
+
+
+class TestExpectationIsTransparent:
+    """Document that E[][] currently has zero semantic effect."""
+
+    def test_E_of_variable_equals_variable(self):
+        """E[][x[1]] produces the same sympy expression as x[1]."""
+        with_E = parse_expression("E[][x[1]]")
+        without_E = parse_expression("x[1]")
+
+        sym_with = ast_to_sympy(with_E)
+        sym_without = ast_to_sympy(without_E)
+
+        # This passes — the expectation is stripped
+        assert sym_with == sym_without
+
+    def test_E_of_expression_equals_expression(self):
+        """E[][beta * C[1]^(-sigma)] produces the same result as beta * C[1]^(-sigma)."""
+        with_E = parse_expression("E[][beta * C[1] ^ (-sigma)]")
+        without_E = parse_expression("beta * C[1] ^ (-sigma)")
+
+        sym_with = ast_to_sympy(with_E)
+        sym_without = ast_to_sympy(without_E)
+
+        assert sym_with == sym_without
+
+    def test_euler_equation_identical_with_and_without_E(self):
+        """
+        The Euler equation gives the same sympy expression with and without E[][].
+
+        ``C[]^(-sigma) = beta * E[][C[1]^(-sigma) * (1 + r[1])]``
+        """
+        with_E = parse_expression("beta * E[][C[1] ^ (-sigma) * (1 + r[1])]")
+        without_E = parse_expression("beta * C[1] ^ (-sigma) * (1 + r[1])")
+
+        sym_with = ast_to_sympy(with_E)
+        sym_without = ast_to_sympy(without_E)
+
+        assert sym_with == sym_without
+
+
+class TestExpectationDoesNotValidateContent:
+    """
+    Document that E[][] does not check whether its argument is uncertain.
+
+    A proper implementation should warn or error when the expectation is applied
+    to known quantities (e.g., E_t[x_{t-1}] = x_{t-1}).
+    """
+
+    def test_E_of_lagged_variable_is_not_flagged(self):
+        """
+        E[][x[-1]] should be redundant, but gEconpy accepts it silently.
+
+        x_{t-1} is known at time t, yet the E[][] is just stripped.
+        """
+        node = parse_expression("E[][x[-1]]")
+        result = ast_to_sympy(node)
+
+        # Currently: just strips E, gives x[-1]
+        x_lag = parsed_var("x", -1)
+        assert result == x_lag
+
+    def test_E_of_current_variable_is_not_flagged(self):
+        """
+        E[][x[]] should be redundant, but gEconpy accepts it silently.
+
+        x_t is known at time t, yet the E[][] is just stripped.
+        """
+        node = parse_expression("E[][x[]]")
+        result = ast_to_sympy(node)
+
+        x_now = parsed_var("x", 0)
+        assert result == x_now
+
+
+class TestExpectationShouldMatterForModels:
+    """
+    Demonstrate cases where a real expectations operator would change solutions.
+
+    These tests are marked xfail because they document *desired future behavior*
+    that the current transparent E[][] cannot support.
+    """
+
+    @pytest.mark.xfail(
+        reason=(
+            "E[][] is transparent: E[][x[1]^2] gives x[1]^2, but a proper "
+            "implementation at second order should add a Jensen's inequality "
+            "correction term E_t[x_{t+1}^2] = (E_t[x_{t+1}])^2 + Var_t(x_{t+1}). "
+            "This only matters at order >= 2."
+        ),
+        strict=True,
+    )
+    def test_jensens_inequality_second_order(self):
+        """
+        At second order, E[x^2] ≠ (E[x])^2.
+
+        For a model with the identity:
+            y[] = E[][x[1]^2]
+
+        A proper second-order expansion should produce:
+            y_t = (E_t[x_{t+1}])^2 + Var_t(x_{t+1})
+
+        But with E[][] stripped, we get:
+            y_t = x_{t+1}^2
+
+        which, when linearized at any order, is missing the variance correction.
+        """
+        # E[][x[1]^2]
+        e_of_x_squared = ast_to_sympy(parse_expression("E[][x[1] ^ 2]"))
+        # x[1]^2
+        x_squared = ast_to_sympy(parse_expression("x[1] ^ 2"))
+
+        # Currently these are identical (E is stripped). At second order they
+        # should differ by the variance correction term.
+        assert e_of_x_squared != x_squared
+
+    @pytest.mark.xfail(
+        reason=(
+            "gEconpy has no syntax for different information sets. "
+            "E_{t-1}[x_{t+1}] cannot be expressed — there is no E[-1][x[1]] syntax. "
+            "This matters for predetermined pricing / sticky information models."
+        ),
+        strict=True,
+    )
+    def test_predetermined_pricing_different_information_set(self):
+        """
+        Predetermined-pricing models need E_{t-1}[...], which has no gEconpy syntax.
+
+        In a sticky-information or predetermined-pricing model, firms set
+        prices at t-1 based on E_{t-1}[...]. This means:
+
+            pi_t = beta * E_{t-1}[pi_{t+1}] + kappa * E_{t-1}[x_t]
+
+        The crucial difference from the standard NKPC:
+            pi_t = beta * E_t[pi_{t+1}] + kappa * x_t
+
+        is that E_{t-1}[x_t] ≠ x_t. The current-period output gap x_t
+        includes surprise shocks that weren't known at t-1. Under
+        predetermined pricing, pi_t should NOT respond to contemporaneous
+        shocks — only to shocks that were anticipated at t-1.
+
+        This test verifies that E_{t-1}[x[]] produces a *different* expression
+        than E_t[x[]] = x[]. Currently fails because there is no E[-1][] syntax.
+        """
+        # The model needs E_{t-1}[x[]] to differ from x[]
+        # With proper implementation, E_{t-1}[x_t] would become an auxiliary
+        # variable (like Dynare's AUX_EXPECT_LAG_1), giving the equation a
+        # different Jacobian structure.
+
+        # Currently: E[][x[]] and x[] are identical
+        e_x = ast_to_sympy(parse_expression("E[][x[]]"))
+        x = ast_to_sympy(parse_expression("x[]"))
+
+        # In a world with proper E[-1][x[]], these should differ
+        # because E_{t-1}[x_t] is a predetermined variable that doesn't
+        # respond to current-period shocks.
+        # For now, even E_t[x_t] = x_t, so this test documents that
+        # the expectation is a no-op.
+        assert e_x != x  # Fails: they are identical
+
+    @pytest.mark.xfail(
+        reason=(
+            "E[][] is transparent, so wrapping vs not wrapping an identity "
+            "equation produces identical model solutions. With a proper "
+            "implementation, E[][f(x[1])] in an identity should mark the "
+            "equation for special handling during linearization."
+        ),
+        strict=True,
+    )
+    def test_identity_with_expectation_differs_from_without(self):
+        """
+        Wrapping an identity in E[][] should change the model, but currently does not.
+
+        Consider two models with identical structure except for E[][]:
+
+        Model A (with E):   P[] = E[][beta * D[1] / D[]]
+        Model B (without):  P[] = beta * D[1] / D[]
+
+        At first order these are the same (certainty equivalence). At second
+        order they differ because E_t[D_{t+1}/D_t] ≠ E_t[D_{t+1}]/D_t when
+        D_{t+1} and D_t are correlated.
+
+        This test checks that the two formulations produce *different* sympy
+        expressions, which they currently don't.
+        """
+        with_E = ast_to_sympy(parse_expression("E[][beta * D[1] / D[]]"))
+        without_E = ast_to_sympy(parse_expression("beta * D[1] / D[]"))
+
+        # Should differ: E[D(+1)/D] ≠ D(+1)/D in general
+        # Currently identical because E is stripped
+        assert with_E != without_E

--- a/tests/parser/transform/test_to_sympy.py
+++ b/tests/parser/transform/test_to_sympy.py
@@ -25,6 +25,7 @@ from gEconpy.parser.transform.to_sympy import (
     equation_to_sympy,
     model_to_sympy,
 )
+from tests.conftest import parsed_symbol, parsed_symbols, parsed_var
 
 
 class TestConvertAtoms:
@@ -85,7 +86,7 @@ class TestConvertOperations:
             right=Parameter(name="b"),
         )
         result = ast_to_sympy(node)
-        a, b = sp.symbols("a b")
+        a, b = parsed_symbols("a b")
         assert result == a + b
 
     def test_subtraction(self):
@@ -95,7 +96,7 @@ class TestConvertOperations:
             right=Parameter(name="b"),
         )
         result = ast_to_sympy(node)
-        a, b = sp.symbols("a b")
+        a, b = parsed_symbols("a b")
         assert result == a - b
 
     def test_multiplication(self):
@@ -105,7 +106,7 @@ class TestConvertOperations:
             right=Parameter(name="b"),
         )
         result = ast_to_sympy(node)
-        a, b = sp.symbols("a b")
+        a, b = parsed_symbols("a b")
         assert result == a * b
 
     def test_division(self):
@@ -115,7 +116,7 @@ class TestConvertOperations:
             right=Parameter(name="b"),
         )
         result = ast_to_sympy(node)
-        a, b = sp.symbols("a b")
+        a, b = parsed_symbols("a b")
         assert result == a / b
 
     def test_power(self):
@@ -125,13 +126,13 @@ class TestConvertOperations:
             right=Parameter(name="alpha"),
         )
         result = ast_to_sympy(node)
-        K, alpha = sp.symbols("K alpha")
+        K, alpha = parsed_symbols("K alpha")
         assert result == K**alpha
 
     def test_negation(self):
         node = UnaryOp(op=Operator.NEG, operand=Parameter(name="x"))
         result = ast_to_sympy(node)
-        x = sp.Symbol("x")
+        x = parsed_symbol("x")
         assert result == -x
 
     def test_nested_operations(self):
@@ -146,7 +147,7 @@ class TestConvertOperations:
             right=Parameter(name="c"),
         )
         result = ast_to_sympy(node)
-        a, b, c = sp.symbols("a b c")
+        a, b, c = parsed_symbols("a b c")
         assert result == (a + b) * c
 
 
@@ -154,19 +155,19 @@ class TestConvertFunctions:
     def test_log(self):
         node = FunctionCall(func_name="log", args=(Parameter(name="x"),))
         result = ast_to_sympy(node)
-        x = sp.Symbol("x")
+        x = parsed_symbol("x")
         assert result == sp.log(x)
 
     def test_exp(self):
         node = FunctionCall(func_name="exp", args=(Parameter(name="x"),))
         result = ast_to_sympy(node)
-        x = sp.Symbol("x")
+        x = parsed_symbol("x")
         assert result == sp.exp(x)
 
     def test_sqrt(self):
         node = FunctionCall(func_name="sqrt", args=(Parameter(name="x"),))
         result = ast_to_sympy(node)
-        x = sp.Symbol("x")
+        x = parsed_symbol("x")
         assert result == sp.sqrt(x)
 
     def test_nested_function(self):
@@ -176,7 +177,7 @@ class TestConvertFunctions:
             args=(FunctionCall(func_name="exp", args=(Parameter(name="x"),)),),
         )
         result = ast_to_sympy(node)
-        x = sp.Symbol("x")
+        x = parsed_symbol("x")
         assert result == sp.log(sp.exp(x))
 
 
@@ -327,8 +328,8 @@ class TestRealEquations:
         node = parse_expression("log(C[]) + log(L[])")
         result = ast_to_sympy(node)
 
-        C = TimeAwareSymbol("C", 0)
-        L = TimeAwareSymbol("L", 0)
+        C = parsed_var("C", 0)
+        L = parsed_var("L", 0)
         expected = sp.log(C) + sp.log(L)
         assert result == expected
 
@@ -337,9 +338,9 @@ class TestRealEquations:
         node = parse_expression("u[] + beta * E[][U[1]]")
         result = ast_to_sympy(node)
 
-        u = TimeAwareSymbol("u", 0)
-        beta = sp.Symbol("beta")
-        U1 = TimeAwareSymbol("U", 1)
+        u = parsed_var("u", 0)
+        beta = parsed_symbol("beta")
+        U1 = parsed_var("U", 1)
         expected = u + beta * U1
         assert result == expected
 
@@ -348,10 +349,10 @@ class TestRealEquations:
         node = parse_expression("A[] * K[-1] ^ alpha * L[] ^ (1 - alpha)")
         result = ast_to_sympy(node)
 
-        A = TimeAwareSymbol("A", 0)
-        K = TimeAwareSymbol("K", -1)
-        L = TimeAwareSymbol("L", 0)
-        alpha = sp.Symbol("alpha")
+        A = parsed_var("A", 0)
+        K = parsed_var("K", -1)
+        L = parsed_var("L", 0)
+        alpha = parsed_symbol("alpha")
         expected = A * K**alpha * L ** (1 - alpha)
         assert result == expected
 
@@ -360,10 +361,10 @@ class TestRealEquations:
         lhs = parse_expression("sigma / beta * (E[][C[1]] - C[])")
         result = ast_to_sympy(lhs)
 
-        sigma = sp.Symbol("sigma")
-        beta = sp.Symbol("beta")
-        C = TimeAwareSymbol("C", 0)
-        C1 = TimeAwareSymbol("C", 1)
+        sigma = parsed_symbol("sigma")
+        beta = parsed_symbol("beta")
+        C = parsed_var("C", 0)
+        C1 = parsed_var("C", 1)
         expected = sigma / beta * (C1 - C)
         assert result == expected
 
@@ -372,9 +373,9 @@ class TestRealEquations:
         node = parse_expression("(1 - delta) * K[-1] + delta * I[]")
         result = ast_to_sympy(node)
 
-        delta = sp.Symbol("delta")
-        K = TimeAwareSymbol("K", -1)
-        I = TimeAwareSymbol("I", 0)
+        delta = parsed_symbol("delta")
+        K = parsed_var("K", -1)
+        I = parsed_var("I", 0)
         expected = (1 - delta) * K + delta * I
         assert result == expected
 
@@ -383,8 +384,8 @@ class TestRealEquations:
         node = parse_expression("L[ss] / K[ss]")
         result = ast_to_sympy(node)
 
-        L_ss = TimeAwareSymbol("L", "ss")
-        K_ss = TimeAwareSymbol("K", "ss")
+        L_ss = parsed_var("L", "ss")
+        K_ss = parsed_var("K", "ss")
         expected = L_ss / K_ss
         assert result == expected
 
@@ -400,9 +401,9 @@ class TestRealEquations:
         node = parse_expression("rho_A * A[-1] + epsilon_A[]")
         result = ast_to_sympy(node)
 
-        rho_A = sp.Symbol("rho_A")
-        A = TimeAwareSymbol("A", -1)
-        epsilon_A = TimeAwareSymbol("epsilon_A", 0)
+        rho_A = parsed_symbol("rho_A")
+        A = parsed_var("A", -1)
+        epsilon_A = parsed_var("epsilon_A", 0)
         expected = rho_A * A + epsilon_A
         assert result == expected
 
@@ -425,7 +426,7 @@ class TestCalibratingEquationConversion:
         assert metadata["is_calibrating"] is True
         assert metadata["calibrating_parameter"].name == "alpha"
         # The equation should be: alpha = lhs - rhs
-        assert result.lhs == sp.Symbol("alpha")
+        assert result.lhs == parsed_symbol("alpha")
 
 
 class TestAssumptionsPropagation:


### PR DESCRIPTION
real=True and finite=True

This allows some extra sympy simplifications. A user can still mark a variable as complex if he wants, but I don't see why he would want.

<!-- readthedocs-preview gEconpy start -->
----
📚 Documentation preview 📚: https://gEconpy--98.org.readthedocs.build/en/98/

<!-- readthedocs-preview gEconpy end -->