### PR TITLE
Add user-defined observation equations to DSGE statespace models

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -50,16 +50,30 @@ jobs:
             test-subset: "tests/ --ignore=tests/model"
             test-marker: ""
 
-          - subset-name: "Windows Test Model"
+          # Windows is a smoke test, not a correctness sweep: model/solver correctness is
+          # OS-independent and covered exhaustively by the Ubuntu jobs above. The Windows jobs
+          # below exercise only the OS-sensitive machinery — pytensor's compile toolchain,
+          # .gcn file loading, multiprocessing — across the core solve/linearize/simulate
+          # pipeline. Pure-algebra suites (parser grammar, block FOCs, plotting, classes) and
+          # the steady-state / statespace / build files run on Ubuntu only. The
+          # test_*_backends_agree and steady-state deselects stay because Windows BLAS
+          # produces slightly different numbers, not because the tests are uninteresting.
+          - subset-name: "Windows Model Integration"
             os: windows-latest
             python-version: "3.13"
-            test-subset: "tests/model --ignore=tests/model/test_steady_state.py --ignore=tests/model/test_statespace.py --ignore=tests/model/test_build.py --deselect tests/model/test_model.py::test_steady_state --deselect tests/model/test_model.py::test_numerical_steady_state --deselect tests/model/test_model.py::test_partially_analytical_steady_state --deselect tests/model/test_model.py::test_all_backends_agree_on_functions --deselect tests/model/test_model.py::test_scipy_wrapped_functions_agree --deselect tests/model/test_model.py::test_all_backends_agree_on_parameters --deselect tests/models/test_model.py::test_simulate"
+            test-subset: "tests/model/test_model.py --deselect tests/model/test_model.py::test_steady_state --deselect tests/model/test_model.py::test_numerical_steady_state --deselect tests/model/test_model.py::test_partially_analytical_steady_state --deselect tests/model/test_model.py::test_all_backends_agree_on_functions --deselect tests/model/test_model.py::test_scipy_wrapped_functions_agree --deselect tests/model/test_model.py::test_all_backends_agree_on_parameters"
             test-marker: "not include_nk"
 
-          - subset-name: "Windows Other Tests"
+          - subset-name: "Windows Model Solve & Diagnostics"
             os: windows-latest
             python-version: "3.13"
-            test-subset: "tests/ --ignore=tests/model"
+            test-subset: "tests/model/test_compile.py tests/model/test_perturbation.py tests/model/test_diagnostics.py tests/model/perfect_foresight"
+            test-marker: "not include_nk"
+
+          - subset-name: "Windows Core Library"
+            os: windows-latest
+            python-version: "3.13"
+            test-subset: "tests/pytensorf tests/solvers tests/parser/test_loader.py tests/test_dynare_convert.py"
             test-marker: "not include_nk"
 
     name: ${{ matrix.subset-name }} (${{ matrix.os }} Python ${{ matrix.python-version }})

--- a/gEconpy/model/build.py
+++ b/gEconpy/model/build.py
@@ -706,6 +706,7 @@ def statespace_from_gcn(
         steady_state_mapping=steady_state_mapping,
         linearized_system=[A, B, C, D],
         var_order=var_order,
+        log_linearized_variables=[v.base_name for v in loglin_vars],
         filter_type=filter_type,
         verbose=verbose,
     )

--- a/gEconpy/model/build.py
+++ b/gEconpy/model/build.py
@@ -4,7 +4,6 @@ import sys
 from pathlib import Path
 from warnings import warn
 
-import pytensor.tensor as pt
 import sympy as sp
 
 from pytensor.graph.replace import graph_replace
@@ -20,7 +19,6 @@ from gEconpy.model.simplification import simplify_constants, simplify_tryreduce
 from gEconpy.model.statespace import DSGEStateSpace
 from gEconpy.model.steady_state import (
     ERROR_FUNCTIONS,
-    _ss_residual_to_pytensor,
     compile_known_ss,
     propagate_steady_state_through_identities,
     simplify_provided_ss_equations,
@@ -632,7 +630,7 @@ def statespace_from_gcn(
             _print_parse_error(e, gcn_path)
         raise
 
-    variables, shocks, equations, _ss_relationships, steady_state_equations, ss_solution_dict = objects
+    variables, shocks, equations, _ss_relationships, _steady_state_equations, ss_solution_dict = objects
     param_dict, hyper_param_dict, deterministic_dict, calib_dict = dictionaries
     param_priors, shock_priors = priors
 
@@ -659,21 +657,6 @@ def statespace_from_gcn(
 
     if steady_state_mapping is None or len(steady_state_mapping) != len(variables):
         raise NotImplementedError("Numeric steady state not yet implemented in StateSpace model")
-
-    equations_pt, cache = _ss_residual_to_pytensor(
-        steady_state_equations,
-        SymbolDictionary(),
-        variables,
-        param_dict,
-        deterministic_dict,
-        calib_dict,
-        cache=cache,
-    )
-
-    # DSGEStateSpace only consumes ss_resid (squared into a penalty in _setup_ss_model).
-    # The Jacobian / error / gradient / Hessian graphs that the model_from_gcn path needs
-    # for numerical SS solving are discarded here, so don't build them.
-    ss_resid = pt.stack(equations_pt) if equations_pt else pt.zeros(0)
 
     if not_loglin_variables is None:
         not_loglin_variables = []
@@ -709,7 +692,6 @@ def statespace_from_gcn(
     }
     replacements = parameter_mapping | steady_state_mapping
 
-    ss_resid = graph_replace(ss_resid, replacements, strict=False)
     A, B, C, D = rewrite_pregrad(graph_replace([A, B, C, D], replacements, strict=False))
 
     return DSGEStateSpace(
@@ -722,7 +704,6 @@ def statespace_from_gcn(
         shock_priors=shock_priors,
         parameter_mapping=parameter_mapping,
         steady_state_mapping=steady_state_mapping,
-        ss_resid=ss_resid,
         linearized_system=[A, B, C, D],
         var_order=var_order,
         filter_type=filter_type,

--- a/gEconpy/model/build.py
+++ b/gEconpy/model/build.py
@@ -707,6 +707,7 @@ def statespace_from_gcn(
         linearized_system=[A, B, C, D],
         var_order=var_order,
         log_linearized_variables=[v.base_name for v in loglin_vars],
+        sympytensor_cache=cache,
         filter_type=filter_type,
         verbose=verbose,
     )

--- a/gEconpy/model/statespace.py
+++ b/gEconpy/model/statespace.py
@@ -22,11 +22,14 @@ from pymc_extras.statespace.utils.constants import (
     SHOCK_DIM,
 )
 from pytensor.graph.replace import graph_replace
+from sympytensor import as_tensor
 
 from gEconpy.classes.containers import SymbolDictionary
 from gEconpy.classes.distributions import CompositeDistribution
 from gEconpy.classes.time_aware_symbol import TimeAwareSymbol
 from gEconpy.model.perturbation import check_bk_condition_pt
+from gEconpy.parser.grammar.expressions import parse_expression
+from gEconpy.parser.transform.to_sympy import ast_to_sympy
 from gEconpy.pytensorf.block import block
 from gEconpy.solvers.backward_looking import solve_policy_function_with_backward_direct_pt
 from gEconpy.solvers.cycle_reduction import cycle_reduction_pt, scan_cycle_reduction
@@ -57,6 +60,7 @@ class DSGEStateSpace(PyMCStateSpace):
         linearized_system: list[pt.TensorVariable],
         var_order: np.ndarray | None = None,
         log_linearized_variables: list[str] | None = None,
+        sympytensor_cache: dict | None = None,
         filter_type: str = "standard",
         verbose: bool = True,
     ):
@@ -145,6 +149,26 @@ class DSGEStateSpace(PyMCStateSpace):
         self._log_linearized_variables: set[str] = set(log_linearized_variables or [])
         self._ss_obs_intercept_states: list[str] = []
 
+        # Shared sympytensor cache from ``statespace_from_gcn``. Reusing it lets
+        # subsequent sympy-to-pytensor conversions (observation equations)
+        # reference the same TensorVariables that key ``steady_state_mapping``
+        # and ``parameter_mapping``.
+        self._sympytensor_cache: dict = sympytensor_cache if sympytensor_cache is not None else {}
+
+        # Linearized obs equations: maps obs-series name to
+        # ``(intercept_pt, {(var_base_name, lag): coeff_pt})``. Pytensor
+        # expressions in the input-parameter placeholders. Populated by
+        # ``configure`` when ``observation_equations`` is supplied.
+        self._obs_equations: dict[str, tuple] = {}
+
+        # Per-variable lag depth required by any observation equation.
+        # Computed at ``configure`` time alongside the linearization.
+        self._obs_lag_depths: dict[str, int] = {}
+
+        # Per-variable starting column of its obs-eq lag chain in the
+        # augmented state vector. Populated at ``configure`` time.
+        self._obs_lag_starts: dict[str, int] = {}
+
         self.verbose = verbose
 
         k_endog = 1  # to be updated later
@@ -224,65 +248,126 @@ class DSGEStateSpace(PyMCStateSpace):
         return Q
 
     def _make_design_matrix(self):
+        """
+        Build the observation design matrix :math:`Z`.
+
+        For each observed state, fill the row with the linearized coefficients
+        from a user-supplied observation equation (parameter-dependent), or with
+        a selector entry (unit weight, or :math:`1/s` for ``mean`` aggregation)
+        on the state's column plus its cumulator slots if any. Returns the
+        constant numpy form when no observation equations are configured and a
+        pytensor matrix otherwise.
+
+        Returns
+        -------
+        Z : ndarray or pt.TensorVariable
+            Constant ``(k_endog, k_states)`` array when every observed state
+            uses the selector form, or a pytensor matrix of the same shape when
+            any observation equation contributes parameter-dependent
+            coefficients.
+        """
         n_cum_lags = self._aggregation_period - 1
         cumulator_vars = self._cumulator_variables
 
-        Z = np.zeros((self.k_endog, self.k_states))
+        if not self._obs_equations:
+            # Pure selector design — keep the existing constant-numpy path.
+            Z = np.zeros((self.k_endog, self.k_states))
+            for i, name in enumerate(self.observed_states):
+                orig_idx = self._orig_state_names.index(name)
+                agg_method = self._temporal_aggregation.get(name)
+                if agg_method in CUMULATOR_AGGREGATIONS:
+                    agg_pos = cumulator_vars.index(name)
+                    cum_start = self._k_orig_states + agg_pos * n_cum_lags
+                    weight = 1.0 / self._aggregation_period if agg_method == "mean" else 1.0
+                    Z[i, orig_idx] = weight
+                    Z[i, cum_start : cum_start + n_cum_lags] = weight
+                else:
+                    Z[i, orig_idx] = 1.0
+            return Z
 
+        # At least one observation equation in play — build Z symbolically.
+        # Use ``inc_subtensor`` for the obs-equation rows so that overlapping
+        # contributions from ``(lag, d)`` aggregation pairs accumulate
+        # (e.g. annual-summed quarterly log-differences telescope).
+        Z_sym = pt.zeros((self.k_endog, self.k_states), dtype=floatX)
         for i, name in enumerate(self.observed_states):
-            orig_idx = self._orig_state_names.index(name)
             agg_method = self._temporal_aggregation.get(name)
 
-            if agg_method in CUMULATOR_AGGREGATIONS:
-                agg_pos = cumulator_vars.index(name)
-                cum_start = self._k_orig_states + agg_pos * n_cum_lags
-
-                weight = 1.0 / self._aggregation_period if agg_method == "mean" else 1.0
-                Z[i, orig_idx] = weight
-                Z[i, cum_start : cum_start + n_cum_lags] = weight
+            if name in self._obs_equations:
+                _, coeffs = self._obs_equations[name]
+                if agg_method in CUMULATOR_AGGREGATIONS:
+                    n_periods = self._aggregation_period
+                    coeff_weight = 1.0 if agg_method == "sum" else 1.0 / n_periods
+                else:
+                    n_periods = 1
+                    coeff_weight = 1.0
+                for (vname, lag), coeff_pt in coeffs.items():
+                    for d in range(n_periods):
+                        effective_lag = lag - d
+                        col = (
+                            self._orig_state_names.index(vname)
+                            if effective_lag == 0
+                            else self._obs_lag_column(vname, effective_lag)
+                        )
+                        Z_sym = pt.inc_subtensor(Z_sym[i, col], coeff_weight * coeff_pt)
             else:
-                # first, last, or not specified: direct selector
-                Z[i, orig_idx] = 1.0
-
-        return Z
+                weight = 1.0 / self._aggregation_period if agg_method == "mean" else 1.0
+                orig_idx = self._orig_state_names.index(name)
+                Z_sym = pt.set_subtensor(Z_sym[i, orig_idx], weight)
+                if agg_method in CUMULATOR_AGGREGATIONS:
+                    agg_pos = cumulator_vars.index(name)
+                    cum_start = self._k_orig_states + agg_pos * n_cum_lags
+                    for k in range(n_cum_lags):
+                        Z_sym = pt.set_subtensor(Z_sym[i, cum_start + k], weight)
+        return Z_sym
 
     def _make_obs_intercept(self) -> pt.TensorVariable:
+        r"""
+        Build the observation-intercept vector :math:`d`.
+
+        For each observed state :math:`v`:
+
+        - If :math:`v` has a user-supplied observation equation, the entry is
+          the linearization's constant term — for example
+          :math:`\log Y_{ss}(p) + \log Z_{ss}(p)` for the BGP growth-rate
+          observation.
+        - Else if :math:`v` is in ``self._ss_obs_intercept_states``, the entry
+          is :math:`\log v_{ss}(p)` (log-linearized) or :math:`v_{ss}(p)`
+          (level-linearized).
+        - Otherwise the entry is zero, appropriate when the data for that
+          series is already in deviation form (HP-cycled, demeaned, etc.).
+
+        Temporal aggregation: ``sum``-aggregated observations get the
+        per-period intercept multiplied by ``aggregation_period``; ``mean``,
+        ``first``, ``last``, and the default no-aggregation case keep the
+        single-period value.
+
+        Returns
+        -------
+        d : pt.TensorVariable
+            Length-``k_endog`` vector of intercepts in the model's input-
+            parameter graph.
         """
-        Build the observation-intercept vector ``d``.
-
-        The predicted observable matches the user's data units when the data is *not* in
-        deviation form. For each observed state ``v``:
-
-        - If ``v`` is in ``self._ss_obs_intercept_states``, the entry is
-          ``log(v_ss(p))`` (log-linearized variables) or ``v_ss(p)`` (level-linearized
-          variables). The framework re-evaluates ``v_ss(p)`` on every parameter draw via
-          ``steady_state_mapping``.
-        - Otherwise, the entry is zero (matches the previous behavior, for users who
-          pre-demean / pre-detrend their data).
-
-        Temporal aggregation: ``sum``-aggregated observations get the per-period
-        intercept multiplied by ``aggregation_period``; ``mean``, ``first``, ``last``,
-        and the default no-aggregation case keep the single-period value.
-        """
-        # Keys of ``steady_state_mapping`` are pytensor TensorVariables named ``<varname>_ss``.
         ss_by_name = {k.name: v for k, v in self.steady_state_mapping.items()}
         ss_set = set(self._ss_obs_intercept_states)
         entries: list[pt.TensorVariable] = []
         for name in self.observed_states:
-            if name not in ss_set:
+            if name in self._obs_equations:
+                intercept_pt, _ = self._obs_equations[name]
+                base = intercept_pt
+            elif name in ss_set:
+                ss_key = f"{name}_ss"
+                if ss_key not in ss_by_name:
+                    raise ValueError(
+                        f"ss_obs_intercept requested for {name!r}, but no symbolic steady state "
+                        f"is available for it. This usually means the variable was eliminated "
+                        f"by tryreduce or has no analytic SS."
+                    )
+                v_ss_expr = ss_by_name[ss_key]
+                base = pt.log(v_ss_expr) if name in self._log_linearized_variables else v_ss_expr
+            else:
                 entries.append(pt.zeros((), dtype=floatX))
                 continue
-
-            ss_key = f"{name}_ss"
-            if ss_key not in ss_by_name:
-                raise ValueError(
-                    f"ss_obs_intercept requested for {name!r}, but no symbolic steady state "
-                    f"is available for it. This usually means the variable was eliminated "
-                    f"by tryreduce or has no analytic SS."
-                )
-            v_ss_expr = ss_by_name[ss_key]
-
-            base = pt.log(v_ss_expr) if name in self._log_linearized_variables else v_ss_expr
 
             agg = self._temporal_aggregation.get(name)
             if agg == "sum":
@@ -292,14 +377,188 @@ class DSGEStateSpace(PyMCStateSpace):
 
         return pt.stack(entries).astype(floatX)
 
+    def _parse_observation_equation(self, name: str, expr_str: str) -> sp.Expr:
+        """
+        Parse a GCN-syntax observation equation into a sympy expression in the model's namespace.
+
+        Accepts contemporaneous and lagged variable references (``v[]``,
+        ``v[-1]``, ...). Leads raise ``ValueError`` — an observation cannot
+        depend on the future.
+
+        Parameters
+        ----------
+        name : str
+            Observed-series name the equation belongs to, used for error
+            messages.
+        expr_str : str
+            GCN-syntax expression in terms of model variables and parameters.
+
+        Returns
+        -------
+        sym : sympy.Expr
+            Parsed expression with free symbols resolved against the model's
+            variable and parameter namespaces.
+        """
+        ast = parse_expression(expr_str, context=f"observation_equations[{name!r}]")
+        # Carry the model variables' assumptions (positive, etc.) through to the
+        # parsed symbols. Sympy equality and hashing include assumptions, so
+        # without this the parsed TimeAwareSymbols would not compare equal to
+        # the model's, and the linearization's ``xreplace`` would silently
+        # leave them in place.
+        assumptions = {v.base_name: dict(v.assumptions0) for v in self.variables}
+        sym = ast_to_sympy(ast, assumptions=assumptions)
+
+        var_names = {v.base_name for v in self.variables}
+        param_names = set(self.param_dict) | set(self.hyper_param_dict)
+
+        for s in sym.free_symbols:
+            if isinstance(s, TimeAwareSymbol):
+                if s.time_index == "ss":
+                    continue
+                if s.time_index > 0:
+                    raise ValueError(
+                        f"Observation equation {name!r} contains a lead reference "
+                        f"{s}. Only contemporaneous and lagged model variables are "
+                        f"allowed."
+                    )
+                if s.base_name not in var_names:
+                    raise ValueError(
+                        f"Observation equation {name!r} references unknown model "
+                        f"variable {s.base_name!r}. Known: {sorted(var_names)}"
+                    )
+            elif s.name not in param_names:
+                raise ValueError(
+                    f"Observation equation {name!r} references unknown symbol "
+                    f"{s.name!r}: not a model variable, parameter, or hyperparameter."
+                )
+        return sym
+
+    def _linearize_observation_equation(self, sym: sp.Expr) -> tuple[sp.Expr, dict[tuple[str, int], sp.Expr]]:
+        r"""
+        First-order linearize an observation equation around the model's steady state.
+
+        Each variable reference :math:`v_{t+k}` in ``sym`` (with :math:`k \le 0`)
+        is substituted with :math:`v_{ss} \exp(\tilde v_k)` (log-linearized
+        variables) or :math:`v_{ss} + \tilde v_k` (level-linearized variables),
+        where :math:`\tilde v_k` is a fresh dummy. The intercept is the value
+        at all :math:`\tilde v_k = 0`; the coefficient on each :math:`\tilde
+        v_k` is the first partial derivative there. The coefficient
+        corresponds to the contribution of :math:`v`'s deviation at lag
+        :math:`k` in the (augmented) state vector, so for a log-linearized
+        :math:`v` it equals
+        :math:`v_{ss}\, \partial g / \partial v_{t+k}\big|_{ss}` (chain rule).
+
+        Parameters
+        ----------
+        sym : sympy.Expr
+            Observation equation in raw (un-linearized) form, in the model's
+            symbol namespace.
+
+        Returns
+        -------
+        intercept : sympy.Expr
+            Constant term :math:`g(x_{ss}, p)` in steady-state symbols and
+            parameters.
+        coeffs : dict mapping (str, int) to sympy.Expr
+            Maps each appearing ``(variable_base_name, time_index)`` pair to
+            its linear coefficient. ``time_index`` is ``0`` for contemporaneous
+            references and negative for lags.
+        """
+        var_by_name = {v.base_name: v for v in self.variables}
+        appearing = {
+            (s.base_name, s.time_index)
+            for s in sym.free_symbols
+            if isinstance(s, TimeAwareSymbol) and s.time_index != "ss"
+        }
+
+        forward: dict[TimeAwareSymbol, sp.Expr] = {}
+        tildes: dict[tuple[str, int], sp.Symbol] = {}
+        for vname, lag in appearing:
+            v = var_by_name[vname]
+            v_at_t = v.set_t(lag)
+            v_ss = v.set_t("ss")
+            lag_tag = "0" if lag == 0 else f"m{-lag}"
+            v_tilde = sp.Symbol(f"_tilde_{vname}_{lag_tag}", real=True)
+            tildes[(vname, lag)] = v_tilde
+            if vname in self._log_linearized_variables:
+                forward[v_at_t] = v_ss * sp.exp(v_tilde)
+            else:
+                forward[v_at_t] = v_ss + v_tilde
+
+        g_sub = sym.xreplace(forward)
+        zero_subs = {tilde: sp.Integer(0) for tilde in tildes.values()}
+
+        intercept = g_sub.xreplace(zero_subs)
+        coeffs: dict[tuple[str, int], sp.Expr] = {}
+        for key, tilde in tildes.items():
+            coeff = sp.diff(g_sub, tilde).xreplace(zero_subs)
+            coeffs[key] = coeff
+
+        return intercept, coeffs
+
+    def _obs_eq_to_pytensor(
+        self, intercept_sym: sp.Expr, coeffs_sym: dict[tuple[str, int], sp.Expr]
+    ) -> tuple[pt.TensorVariable, dict[tuple[str, int], pt.TensorVariable]]:
+        """
+        Convert the sympy linearization output to pytensor expressions in the model's input parameters.
+
+        Uses ``self._sympytensor_cache`` so that the resulting TensorVariables
+        for steady-state symbols and parameters share identity with the
+        existing keys in ``self.steady_state_mapping`` and
+        ``self.parameter_mapping``. A subsequent ``graph_replace`` with
+        ``steady_state_mapping`` swaps each steady-state symbol for its
+        expression in input parameters.
+
+        Parameters
+        ----------
+        intercept_sym : sympy.Expr
+            Constant term of the linearization.
+        coeffs_sym : dict mapping (str, int) to sympy.Expr
+            Coefficient of each appearing ``(variable, lag)`` pair.
+
+        Returns
+        -------
+        intercept_pt : pt.TensorVariable
+            Pytensor scalar in input-parameter placeholders.
+        coeffs_pt : dict mapping (str, int) to pt.TensorVariable
+            Pytensor scalars in input-parameter placeholders, one per
+            ``(variable, lag)`` pair.
+        """
+
+        def to_tensor(sym_expr):
+            tv = as_tensor(sym_expr, self._sympytensor_cache)
+            # sympy integers (e.g. 0 or 1) come through as Python ints — wrap.
+            if not isinstance(tv, pt.Variable):
+                tv = pt.as_tensor_variable(tv)
+            return tv
+
+        intercept_pt = to_tensor(intercept_sym)
+        coeffs_pt = {key: to_tensor(c_sym) for key, c_sym in coeffs_sym.items()}
+
+        # Substitute SS-tensor placeholders with their parameter-dependent
+        # expressions, then cast to floatX (sympy 0/1 come through as int constants).
+        ss_replace = dict(self.steady_state_mapping)
+        intercept_pt = pt.cast(graph_replace(intercept_pt, ss_replace, strict=False), floatX)
+        coeffs_pt = {
+            vname: pt.cast(graph_replace(c, ss_replace, strict=False), floatX) for vname, c in coeffs_pt.items()
+        }
+        return intercept_pt, coeffs_pt
+
     @property
     def _n_cumulator_states(self) -> int:
-        n_cumulator_vars = sum(1 for m in self._temporal_aggregation.values() if m in CUMULATOR_AGGREGATIONS)
-        return n_cumulator_vars * (self._aggregation_period - 1)
+        return len(self._cumulator_variables) * (self._aggregation_period - 1)
 
     @property
     def _cumulator_variables(self) -> list[str]:
-        return [var for var, method in self._temporal_aggregation.items() if method in CUMULATOR_AGGREGATIONS]
+        # Cumulator aggregation of an observation equation lives in the obs-eq
+        # lag block (since the obs-series name may not match a model variable);
+        # exclude those from this list so ``_augment_transition`` doesn't try
+        # to index them in the model-variable namespace.
+        return [
+            var
+            for var, method in self._temporal_aggregation.items()
+            if method in CUMULATOR_AGGREGATIONS and var not in self._obs_equations
+        ]
 
     @property
     def _orig_state_names(self) -> list[str]:
@@ -312,6 +571,19 @@ class DSGEStateSpace(PyMCStateSpace):
             for var in self._cumulator_variables
             for lag in range(1, self._aggregation_period)
         ]
+
+    @property
+    def _n_obs_lag_states(self) -> int:
+        return sum(self._obs_lag_depths.values())
+
+    @property
+    def _obs_lag_state_names(self) -> list[str]:
+        return [f"{var}_obs_lag{k}" for var, depth in self._obs_lag_depths.items() for k in range(1, depth + 1)]
+
+    def _obs_lag_column(self, var_name: str, lag: int) -> int:
+        """Return the augmented-state column index for ``var_name`` lagged by ``-lag`` (lag<0)."""
+        depth = -lag
+        return self._obs_lag_starts[var_name] + (depth - 1)
 
     def _augment_transition(self, T: pt.TensorVariable) -> pt.TensorVariable:
         """
@@ -367,6 +639,50 @@ class DSGEStateSpace(PyMCStateSpace):
             ]
         )
 
+    def _append_obs_lag_block(self, T_aug: pt.TensorVariable) -> pt.TensorVariable:
+        """
+        Append shift-companion chains for variables referenced at non-zero lag in obs equations.
+
+        For each variable :math:`v` with required lag depth :math:`d`, append
+        :math:`d` slots; slot 1 copies :math:`v` from the previous time step,
+        and each subsequent slot copies the prior slot. The first slot's row
+        of the augmented transition selects the column corresponding to
+        :math:`v`'s entry in the existing augmented state vector.
+
+        Parameters
+        ----------
+        T_aug : pt.TensorVariable
+            Augmented transition matrix, with the cumulator block already
+            appended.
+
+        Returns
+        -------
+        T_aug : pt.TensorVariable
+            Same matrix with the obs-eq lag block appended in the trailing
+            rows and columns.
+        """
+        n_obs_lag = self._n_obs_lag_states
+        if n_obs_lag == 0:
+            return T_aug
+
+        k_prev = self._k_orig_states + self._n_cumulator_states
+        F_lag = pt.zeros((n_obs_lag, k_prev), dtype=floatX)
+        C_lag = pt.zeros((n_obs_lag, n_obs_lag), dtype=floatX)
+        for vname, depth in self._obs_lag_depths.items():
+            orig_idx = self._orig_state_names.index(vname)
+            block_start = self._obs_lag_starts[vname] - k_prev
+            F_lag = pt.set_subtensor(F_lag[block_start, orig_idx], 1.0)
+            for k in range(1, depth):
+                C_lag = pt.set_subtensor(C_lag[block_start + k, block_start + k - 1], 1.0)
+
+        zero_block = pt.zeros((k_prev, n_obs_lag), dtype=floatX)
+        return block(
+            [
+                [T_aug, zero_block],
+                [F_lag, C_lag],
+            ]
+        )
+
     def _augment_selection(self, R: pt.TensorVariable) -> pt.TensorVariable:
         """
         Augment the selection matrix with cumulator rows for temporally aggregated variables.
@@ -389,12 +705,11 @@ class DSGEStateSpace(PyMCStateSpace):
         R_aug : pt.TensorVariable
             Augmented (k_orig + n_cum) x k_posdef selection matrix.
         """
-        if not self._cumulator_variables:
+        n_extra = self._n_cumulator_states + self._n_obs_lag_states
+        if n_extra == 0:
             return R
 
-        n_cum = self._n_cumulator_states
-
-        zeros = pt.zeros((n_cum, self.k_posdef), dtype=floatX)
+        zeros = pt.zeros((n_extra, self.k_posdef), dtype=floatX)
         return pt.join(-2, R, zeros)
 
     def make_symbolic_graph(self):
@@ -427,6 +742,18 @@ class DSGEStateSpace(PyMCStateSpace):
             self.linearized_system, constant_replacements, strict=False
         )
 
+        # Apply the same constant substitution to any cached obs-equation tensors so
+        # ``constant_params`` parameters are baked in there too (otherwise they would
+        # remain as free graph inputs and ``compile_logp`` would fail to bind them).
+        if constant_replacements and self._obs_equations:
+            self._obs_equations = {
+                name: (
+                    graph_replace(intercept_pt, constant_replacements, strict=False),
+                    {v: graph_replace(c, constant_replacements, strict=False) for v, c in coeffs_pt.items()},
+                )
+                for name, (intercept_pt, coeffs_pt) in self._obs_equations.items()
+            }
+
         # A/B/C have columns in ``var_order`` (D's columns are shocks). Translate
         # ``lead_var_idx`` from original variable positions to permuted positions.
         permuted_lead_var_idx = self.inv_var_order[self.lead_var_idx]
@@ -443,13 +770,21 @@ class DSGEStateSpace(PyMCStateSpace):
         self._policy_resid = resid
 
         T_aug = self._augment_transition(T)
+        T_aug = self._append_obs_lag_block(T_aug)
         R_aug = self._augment_selection(R)
 
         self.ssm["transition"] = T_aug
         self.ssm["selection"] = R_aug
         self.ssm["design"] = self._make_design_matrix()
-        if self._ss_obs_intercept_states:
-            self.ssm["obs_intercept"] = self._make_obs_intercept()
+        if self._ss_obs_intercept_states or self._obs_equations:
+            obs_intercept = self._make_obs_intercept()
+            # ``_make_obs_intercept`` reads ``self.steady_state_mapping`` directly for the
+            # ``ss_obs_intercept`` branch — those SS expressions are in free parameter
+            # placeholders, so ``constant_params`` leaks unless we bake constants in
+            # here too.
+            if constant_replacements:
+                obs_intercept = graph_replace(obs_intercept, constant_replacements, strict=False)
+            self.ssm["obs_intercept"] = obs_intercept
 
         Q = self._setup_state_covariance()
 
@@ -479,6 +814,7 @@ class DSGEStateSpace(PyMCStateSpace):
         temporal_aggregation: dict[str, str] | None = None,
         aggregation_period: int = 4,
         ss_obs_intercept: list[str] | None = None,
+        observation_equations: dict[str, str] | None = None,
         solver: str = "gensys",
         mode: str | None = None,
         verbose=True,
@@ -487,20 +823,21 @@ class DSGEStateSpace(PyMCStateSpace):
         use_adjoint_gradients: bool = True,
         use_direct_lyapunov: bool = False,
     ):
-        """
+        r"""
         Configure the statespace model for estimation.
 
         Parameters
         ----------
         observed_states : list of str
-            Names of states to treat as observed.
+            Names of observed series, in data-column order. Each entry is either a
+            model variable's ``base_name`` or a key in ``observation_equations``.
         measurement_error : list of str, optional
             Observed states that have measurement error.
         constant_params : list of str or "auto", optional
             Parameters held constant (not estimated). ``"auto"`` freezes all parameters without priors.
         full_shock_covaraince : bool
             If True, estimate a full shock covariance matrix instead of diagonal.
-        temporal_aggregation : dict of str to {"sum", "mean", "first", "last"}, optional
+        temporal_aggregation : dict of str to str, optional
             Observed states that require temporal aggregation or explicit low-frequency timing.
 
             - ``"sum"``: Flow variables like GDP (observed = sum of ``aggregation_period`` values).
@@ -521,15 +858,19 @@ class DSGEStateSpace(PyMCStateSpace):
         ss_obs_intercept : list of str, optional
             Observed states for which to populate ``ssm["obs_intercept"]`` with a
             parameter-dependent steady-state value, re-evaluated on every parameter draw.
-            For each entry, the intercept is ``log(v_ss(p))`` if the variable was
-            log-linearized when building the model and ``v_ss(p)`` if it was
+            For each entry, the intercept is :math:`\\log v_{ss}(p)` if the variable was
+            log-linearized when building the model and :math:`v_{ss}(p)` if it was
             level-linearized. Observed states *not* in this list keep an
-            ``obs_intercept`` of zero. Use this when the data for that series is already in
-            deviation form (HP-cycled, demeaned, etc.).
-
-            Defaults to ``None``, which is equivalent to an empty list. Pass
-            ``observed_states`` to enable per-draw SS subtraction for every observed
-            series.
+            ``obs_intercept`` of zero — appropriate when the data is already in deviation
+            form (HP-cycled, demeaned, etc.). Pass ``observed_states`` to enable per-draw
+            steady-state subtraction for every observed series. Default ``None`` (no
+            entries; ``obs_intercept`` left at zero).
+        observation_equations : dict mapping str to str, optional
+            Override map keyed by observed-series name (must be a subset of
+            ``observed_states``). Values are GCN-syntax expressions in model
+            variables and parameters, e.g. ``"log(Y[]) - log(Y[-1]) + log(Z[])"``.
+            Contemporaneous and lagged references are accepted; leads are not.
+            A name in this dict cannot also appear in ``ss_obs_intercept``.
         solver : str
             Perturbation solver to use.
         mode : str, optional
@@ -545,8 +886,10 @@ class DSGEStateSpace(PyMCStateSpace):
         use_direct_lyapunov : bool
             Use direct (rather than bilinear) Lyapunov solver.
         """
-        # Set up observed states
-        unknown_states = [x for x in observed_states if x not in self.state_names]
+        # Set up observed states. Names with a user-supplied observation equation
+        # are allowed not to correspond to a model state.
+        obs_eq_names = set(observation_equations or {})
+        unknown_states = [x for x in observed_states if x not in self.state_names and x not in obs_eq_names]
         if len(unknown_states) > 0:
             raise ValueError(
                 f"The following states are unknown to the model and cannot be set as observed: "
@@ -597,6 +940,24 @@ class DSGEStateSpace(PyMCStateSpace):
             if ss_unknown:
                 raise ValueError(f"ss_obs_intercept references unknown model variables: {', '.join(ss_unknown)}")
 
+        # Validate observation_equations: keys subset of observed_states, no overlap
+        # with ss_obs_intercept. The per-equation symbol resolution happens below
+        # when we build the linearization (so we get a single error site).
+        if observation_equations is None:
+            observation_equations = {}
+        else:
+            unknown_keys = [k for k in observation_equations if k not in observed_states]
+            if unknown_keys:
+                raise ValueError(
+                    f"The following observation_equations entries are not in observed_states: {', '.join(unknown_keys)}"
+                )
+            overlap = set(observation_equations) & set(ss_obs_intercept)
+            if overlap:
+                raise ValueError(
+                    f"The following observed states appear in both observation_equations and "
+                    f"ss_obs_intercept: {', '.join(sorted(overlap))}. An observation equation "
+                    f"already determines its intercept; remove these names from one or the other."
+                )
         # Validate constant params
         if constant_params is None:
             constant_params = []
@@ -650,6 +1011,29 @@ class DSGEStateSpace(PyMCStateSpace):
         self._aggregation_period = aggregation_period
         self._ss_obs_intercept_states = ss_obs_intercept
 
+        # Parse + linearize observation equations now so any errors surface here
+        # at configure time rather than mid-graph-build.
+        self._obs_equations = {}
+        for obs_name, expr_str in observation_equations.items():
+            sym = self._parse_observation_equation(obs_name, expr_str)
+            intercept_sym, coeffs_sym = self._linearize_observation_equation(sym)
+            intercept_pt, coeffs_pt = self._obs_eq_to_pytensor(intercept_sym, coeffs_sym)
+            self._obs_equations[obs_name] = (intercept_pt, coeffs_pt)
+
+        # Per-variable lag depth required by each obs equation, including the
+        # ``aggregation_period - 1`` headroom needed to broadcast coefficients
+        # across the cumulator window when ``sum``/``mean`` aggregation is on.
+        # A reference at lag ``-k`` with sum/mean aggregation over ``s`` periods
+        # contributes at effective lags ``-k, -k-1, ..., -k-(s-1)``, so the
+        # deepest effective lag is ``k + (s-1)``.
+        self._obs_lag_depths = {}
+        for obs_name, (_intercept_pt, coeffs_pt) in self._obs_equations.items():
+            broadcast = aggregation_period - 1 if temporal_aggregation.get(obs_name) in CUMULATOR_AGGREGATIONS else 0
+            for vname, lag in coeffs_pt:
+                depth_required = -lag + broadcast
+                if depth_required > 0:
+                    self._obs_lag_depths[vname] = max(self._obs_lag_depths.get(vname, 0), depth_required)
+
         self.full_covariance = full_shock_covaraince
         self.use_direct_lyapunov = use_direct_lyapunov
         self._configured = True
@@ -657,9 +1041,25 @@ class DSGEStateSpace(PyMCStateSpace):
         self._solver_kwargs = solver_kwargs
         self._mode = mode
 
-        n_cumulator_vars = sum(1 for m in temporal_aggregation.values() if m in CUMULATOR_AGGREGATIONS)
+        # Cumulator-aggregated observed states that are also observation equations
+        # route their lag storage through the obs-eq lag block, not the cumulator
+        # block — exclude them here to match ``_cumulator_variables``.
+        n_cumulator_vars = sum(
+            1
+            for name, method in temporal_aggregation.items()
+            if method in CUMULATOR_AGGREGATIONS and name not in self._obs_equations
+        )
         n_cumulator = n_cumulator_vars * (aggregation_period - 1)
-        k_states_aug = self._k_orig_states + n_cumulator
+        n_obs_lag = sum(self._obs_lag_depths.values())
+        k_states_aug = self._k_orig_states + n_cumulator + n_obs_lag
+
+        # Fixed-order layout of the obs-eq lag block: each variable's slots run
+        # consecutively, in the dict's insertion order.
+        self._obs_lag_starts = {}
+        offset = self._k_orig_states + n_cumulator
+        for vname, depth in self._obs_lag_depths.items():
+            self._obs_lag_starts[vname] = offset
+            offset += depth
 
         super().__init__(
             k_endog,
@@ -679,8 +1079,9 @@ class DSGEStateSpace(PyMCStateSpace):
         observed_states = self._obs_state_names if self._obs_state_names is not None else []
         hidden_states = [State(name=x.base_name, observed=False) for x in self.variables]
         cumulator_states = [State(name=name, observed=False) for name in self._cumulator_state_names]
+        obs_lag_states = [State(name=name, observed=False) for name in self._obs_lag_state_names]
         observed_states = [State(name=name, observed=True) for name in observed_states]
-        return *hidden_states, *cumulator_states, *observed_states
+        return *hidden_states, *cumulator_states, *obs_lag_states, *observed_states
 
     def set_parameters(self) -> tuple[Parameter, ...]:
         # TODO: Extract information from assumptions and use them to denote constraints on the parameters

--- a/gEconpy/model/statespace.py
+++ b/gEconpy/model/statespace.py
@@ -54,7 +54,6 @@ class DSGEStateSpace(PyMCStateSpace):
         shock_priors: SymbolDictionary[str, CompositeDistribution],
         parameter_mapping: dict[pt.TensorVariable, pt.TensorVariable],
         steady_state_mapping: dict[pt.TensorVariable, pt.TensorVariable],
-        ss_resid: pt.TensorVariable,
         linearized_system: list[pt.TensorVariable],
         var_order: np.ndarray | None = None,
         filter_type: str = "standard",
@@ -87,9 +86,6 @@ class DSGEStateSpace(PyMCStateSpace):
             deterministic.
         steady_state_mapping: dict
             Symbolic function mapping input parameters to the steady state values of the model
-        ss_resid: pt.TensorVariable
-            Symbolic vector of (signed) residuals of the steady state equations. Used as a penalty term
-            during PyMC sampling to flag parameter draws whose analytical SS does not satisfy the FOCs.
         linearized_system: list of pt.TensorVariable
             List of four symbolic expressions representing the linearized system of equations as partial
             jacobians of the model equations with respect to variables at time t+1 (A), t (B), t-1 (C), and with
@@ -108,8 +104,6 @@ class DSGEStateSpace(PyMCStateSpace):
         self.parameter_mapping = parameter_mapping
         self.steady_state_mapping = steady_state_mapping
         self.input_parameters = [x for x in parameter_mapping if x.name in param_dict]
-
-        self.ss_resid = ss_resid
 
         self.linearized_system = linearized_system
 
@@ -132,7 +126,6 @@ class DSGEStateSpace(PyMCStateSpace):
         self._mode = None
         self._linearized_system_subbed: list | None = None
         self._policy_graph: list | None = None
-        self._ss_resid: pt.TensorVariable | None = None
 
         self._bk_output = None
         self._policy_resid = None
@@ -216,8 +209,7 @@ class DSGEStateSpace(PyMCStateSpace):
 
         # ``pt.diag(stack(...))`` is auto-tagged diagonal by AssumptionFeature, which propagates
         # symmetric/PSD through the congruence rule (R Q R'), enabling cholesky-based solves and
-        # significant speedups in compile_dlogp for HMC sampling. The string-only setter
-        # bypasses the SetSubtensor wrap that the slice-form would impose.
+        # significant speedups in compile_dlogp for HMC sampling.
         sigmas = [self.make_and_register_variable(f"sigma_{shock.base_name}", shape=()) for shock in self.shocks]
         Q = pt.diag(pt.stack([s**2 for s in sigmas]))
         self.ssm["state_cov"] = Q
@@ -389,24 +381,19 @@ class DSGEStateSpace(PyMCStateSpace):
         T, R = self._setup_policy_matrices(A, B, C, D)
         resid = pt.square(A + B @ T + C @ T @ T).sum()
 
-        ss_resid = graph_replace(self.ss_resid, constant_replacements, strict=False)
-        ss_resid = pt.square(ss_resid).sum()
-
         T = rewrite_pregrad(T)
         R = rewrite_pregrad(R)
         resid = rewrite_pregrad(resid)
-        ss_resid = rewrite_pregrad(ss_resid)
 
         self._policy_graph = [T, R]
         self._policy_resid = resid
-        self._ss_resid = ss_resid
 
         T_aug = self._augment_transition(T)
         R_aug = self._augment_selection(R)
 
-        self.ssm["transition", :, :] = T_aug
-        self.ssm["selection", :, :] = R_aug
-        self.ssm["design", :, :] = self._make_design_matrix()
+        self.ssm["transition"] = T_aug
+        self.ssm["selection"] = R_aug
+        self.ssm["design"] = self._make_design_matrix()
 
         Q = self._setup_state_covariance()
 
@@ -422,12 +409,10 @@ class DSGEStateSpace(PyMCStateSpace):
                 H = pt.diag(diag_vec)
             self.ssm["obs_cov"] = H
 
-        self.ssm["initial_state", :] = pt.zeros(self.k_states)
+        self.ssm["initial_state"] = pt.zeros(self.k_states)
 
         method = "direct" if self.use_direct_lyapunov else "bilinear"
-        self.ssm["initial_state_cov", :, :] = pt.linalg.solve_discrete_lyapunov(
-            T_aug, R_aug @ Q @ R_aug.T, method=method
-        )
+        self.ssm["initial_state_cov"] = pt.linalg.solve_discrete_lyapunov(T_aug, R_aug @ Q @ R_aug.T, method=method)
 
     def configure(
         self,
@@ -663,8 +648,7 @@ class DSGEStateSpace(PyMCStateSpace):
         add_norm_check: bool = True,
         add_bk_check: bool = False,
         add_solver_success_check: bool = False,
-        add_steady_state_penalty: bool = True,
-        resid_penalty: float = 1.0,
+        solver_tol: float = 1e-8,
     ) -> None:
         super().build_statespace_graph(
             data=data,
@@ -688,8 +672,8 @@ class DSGEStateSpace(PyMCStateSpace):
             n_steps = graph_replace(self._n_steps, replace=replacement_dict, strict=False)
             pm.Deterministic("n_cycle_steps", n_steps.astype(int))
 
-        policy_resid, *bk_output, ss_resid = graph_replace(
-            [self._policy_resid, *self._bk_output, self._ss_resid],
+        policy_resid, *bk_output = graph_replace(
+            [self._policy_resid, *self._bk_output],
             replace=replacement_dict,
             strict=False,
         )
@@ -697,6 +681,9 @@ class DSGEStateSpace(PyMCStateSpace):
         bk_satisfied, _n_forward, _n_gt_one = bk_output
 
         if add_norm_check:
+            # Diagnostics-only: expose the deterministic and stochastic recursion residuals
+            # as Deterministics for posterior inspection. No Potential is added because the
+            # solver-convergence check below already gates the logp.
             n_vars, n_shocks = R.shape
             tm1_grid = np.array([[eq.has(var.set_t(-1)) for var in self.variables] for eq in self.equations])
             t_grid = np.array([[eq.has(var.set_t(0)) for var in self.variables] for eq in self.equations])
@@ -715,29 +702,19 @@ class DSGEStateSpace(PyMCStateSpace):
             R_prime = T[:, state_var_mask]
             S_prime = QQ[:, shock_idx]
 
-            norm_deterministic = pm.Deterministic(
-                "deterministic_norm",
-                pt.linalg.norm(A_prime + B @ R_prime + C @ R_prime @ P),
-            )
-            norm_stochastic = pm.Deterministic("stochastic_norm", pt.linalg.norm(B @ S_prime + C @ R_prime @ Q + D))
-
-            # Add penalty terms to the likelihood to rule out invalid solutions
-            pm.Potential(
-                "solution_norm_penalty",
-                -resid_penalty * (norm_deterministic + norm_stochastic),
-            )
+            pm.Deterministic("deterministic_norm", pt.linalg.norm(A_prime + B @ R_prime + C @ R_prime @ P))
+            pm.Deterministic("stochastic_norm", pt.linalg.norm(B @ S_prime + C @ R_prime @ Q + D))
 
         if add_bk_check:
             pm.Deterministic("bk_satisfied", bk_satisfied)
             pm.Potential("bk_condition_satisfied", pt.switch(pt.eq(bk_satisfied, 0.0), -np.inf, 0.0))
 
         if add_solver_success_check:
-            policy_resid = pm.Deterministic("policy_resid", policy_resid)
-            pm.Potential("policy_resid_penalty", -resid_penalty * policy_resid)
-
-        if add_steady_state_penalty:
-            ss_resid = pm.Deterministic("ss_resid", ss_resid)
-            pm.Potential("steady_state_resid_penalty", -resid_penalty * ss_resid)
+            pm.Deterministic("policy_resid", policy_resid)
+            pm.Potential(
+                "policy_resid_within_tol",
+                pt.switch(pt.lt(policy_resid, solver_tol), 0.0, -np.inf),
+            )
 
     def to_pymc(self, exclude_priors: list[str] | None = None):
         if exclude_priors is None:

--- a/gEconpy/model/statespace.py
+++ b/gEconpy/model/statespace.py
@@ -56,6 +56,7 @@ class DSGEStateSpace(PyMCStateSpace):
         steady_state_mapping: dict[pt.TensorVariable, pt.TensorVariable],
         linearized_system: list[pt.TensorVariable],
         var_order: np.ndarray | None = None,
+        log_linearized_variables: list[str] | None = None,
         filter_type: str = "standard",
         verbose: bool = True,
     ):
@@ -90,6 +91,10 @@ class DSGEStateSpace(PyMCStateSpace):
             List of four symbolic expressions representing the linearized system of equations as partial
             jacobians of the model equations with respect to variables at time t+1 (A), t (B), t-1 (C), and with
             respect to exogenous shocks (D), each evaluated at the (symbolic) steady state.
+        log_linearized_variables: list of str, optional
+            Base names of variables that were log-linearized when building ``linearized_system``. Used by
+            ``configure(ss_obs_intercept=...)`` to decide whether an observation intercept entry is
+            ``log(v_ss(p))`` (log-linearized) or ``v_ss(p)`` (level-linearized).
         verbose: bool
             If True, show diagnostic messages.
         """
@@ -136,6 +141,9 @@ class DSGEStateSpace(PyMCStateSpace):
         self._temporal_aggregation: dict[str, str] = {}
         self._aggregation_period: int = 4
         self._k_orig_states: int = len(variables)
+
+        self._log_linearized_variables: set[str] = set(log_linearized_variables or [])
+        self._ss_obs_intercept_states: list[str] = []
 
         self.verbose = verbose
 
@@ -237,6 +245,52 @@ class DSGEStateSpace(PyMCStateSpace):
                 Z[i, orig_idx] = 1.0
 
         return Z
+
+    def _make_obs_intercept(self) -> pt.TensorVariable:
+        """
+        Build the observation-intercept vector ``d``.
+
+        The predicted observable matches the user's data units when the data is *not* in
+        deviation form. For each observed state ``v``:
+
+        - If ``v`` is in ``self._ss_obs_intercept_states``, the entry is
+          ``log(v_ss(p))`` (log-linearized variables) or ``v_ss(p)`` (level-linearized
+          variables). The framework re-evaluates ``v_ss(p)`` on every parameter draw via
+          ``steady_state_mapping``.
+        - Otherwise, the entry is zero (matches the previous behavior, for users who
+          pre-demean / pre-detrend their data).
+
+        Temporal aggregation: ``sum``-aggregated observations get the per-period
+        intercept multiplied by ``aggregation_period``; ``mean``, ``first``, ``last``,
+        and the default no-aggregation case keep the single-period value.
+        """
+        # Keys of ``steady_state_mapping`` are pytensor TensorVariables named ``<varname>_ss``.
+        ss_by_name = {k.name: v for k, v in self.steady_state_mapping.items()}
+        ss_set = set(self._ss_obs_intercept_states)
+        entries: list[pt.TensorVariable] = []
+        for name in self.observed_states:
+            if name not in ss_set:
+                entries.append(pt.zeros((), dtype=floatX))
+                continue
+
+            ss_key = f"{name}_ss"
+            if ss_key not in ss_by_name:
+                raise ValueError(
+                    f"ss_obs_intercept requested for {name!r}, but no symbolic steady state "
+                    f"is available for it. This usually means the variable was eliminated "
+                    f"by tryreduce or has no analytic SS."
+                )
+            v_ss_expr = ss_by_name[ss_key]
+
+            base = pt.log(v_ss_expr) if name in self._log_linearized_variables else v_ss_expr
+
+            agg = self._temporal_aggregation.get(name)
+            if agg == "sum":
+                entries.append(self._aggregation_period * base)
+            else:
+                entries.append(base)
+
+        return pt.stack(entries).astype(floatX)
 
     @property
     def _n_cumulator_states(self) -> int:
@@ -394,6 +448,8 @@ class DSGEStateSpace(PyMCStateSpace):
         self.ssm["transition"] = T_aug
         self.ssm["selection"] = R_aug
         self.ssm["design"] = self._make_design_matrix()
+        if self._ss_obs_intercept_states:
+            self.ssm["obs_intercept"] = self._make_obs_intercept()
 
         Q = self._setup_state_covariance()
 
@@ -422,6 +478,7 @@ class DSGEStateSpace(PyMCStateSpace):
         full_shock_covaraince: bool = False,
         temporal_aggregation: dict[str, str] | None = None,
         aggregation_period: int = 4,
+        ss_obs_intercept: list[str] | None = None,
         solver: str = "gensys",
         mode: str | None = None,
         verbose=True,
@@ -461,6 +518,18 @@ class DSGEStateSpace(PyMCStateSpace):
             Number of model periods per low-frequency observation. For example, 4 when fitting
             a quarterly model with annual data, or 3 for a monthly model with quarterly data.
             Default is 4.
+        ss_obs_intercept : list of str, optional
+            Observed states for which to populate ``ssm["obs_intercept"]`` with a
+            parameter-dependent steady-state value, re-evaluated on every parameter draw.
+            For each entry, the intercept is ``log(v_ss(p))`` if the variable was
+            log-linearized when building the model and ``v_ss(p)`` if it was
+            level-linearized. Observed states *not* in this list keep an
+            ``obs_intercept`` of zero. Use this when the data for that series is already in
+            deviation form (HP-cycled, demeaned, etc.).
+
+            Defaults to ``None``, which is equivalent to an empty list. Pass
+            ``observed_states`` to enable per-draw SS subtraction for every observed
+            series.
         solver : str
             Perturbation solver to use.
         mode : str, optional
@@ -515,6 +584,19 @@ class DSGEStateSpace(PyMCStateSpace):
             if has_cumulator_vars and aggregation_period < 2:
                 raise ValueError(f"aggregation_period must be >= 2 for sum/mean aggregation, got {aggregation_period}")
 
+        # Validate ss_obs_intercept
+        if ss_obs_intercept is None:
+            ss_obs_intercept = []
+        else:
+            unknown_vars = [x for x in ss_obs_intercept if x not in observed_states]
+            if unknown_vars:
+                raise ValueError(
+                    f"The following ss_obs_intercept entries are not in observed_states: {', '.join(unknown_vars)}"
+                )
+            ss_unknown = [name for name in ss_obs_intercept if not any(v.base_name == name for v in self.variables)]
+            if ss_unknown:
+                raise ValueError(f"ss_obs_intercept references unknown model variables: {', '.join(ss_unknown)}")
+
         # Validate constant params
         if constant_params is None:
             constant_params = []
@@ -566,6 +648,7 @@ class DSGEStateSpace(PyMCStateSpace):
 
         self._temporal_aggregation = temporal_aggregation
         self._aggregation_period = aggregation_period
+        self._ss_obs_intercept_states = ss_obs_intercept
 
         self.full_covariance = full_shock_covaraince
         self.use_direct_lyapunov = use_direct_lyapunov

--- a/gEconpy/plotting.py
+++ b/gEconpy/plotting.py
@@ -1598,7 +1598,7 @@ def plot_kalman_filter(
     fig: Figure | None = None,
     figsize: tuple[int, int] = (14, 6),
     dpi: int = 144,
-    observed=False,
+    observed: bool = False,
 ):
     """
     Plot Kalman filter, prediction or smoothed series for variables in idata.
@@ -1624,8 +1624,10 @@ def plot_kalman_filter(
         Figure size in inches.
     dpi : int, optional
         Figure DPI.
-    cmap : str, optional
-        Colormap name.
+    observed : bool, optional
+        If True, plot the observed states together with the data series they
+        are fit against. If False, plot the model's latent states. Default
+        False.
 
     Returns
     -------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -253,6 +253,10 @@ lines-between-types = 1
     "ARG003", # Allow unused arguments in test-double classmethods implementing an interface
 ]
 
+'tests/model/test_statespace.py' = [
+    'ARG005'
+]
+
 'docs/source/examples/*/*.ipynb' = [
     'F821', # Notebooks uses direct assignment to globals, so ruff thinks variables are not declared
     'PLR2004', # Allow magic numbers in notebooks

--- a/tests/_resources/test_gcns/rbc_2_block_obs_eq.gcn
+++ b/tests/_resources/test_gcns/rbc_2_block_obs_eq.gcn
@@ -1,0 +1,97 @@
+block STEADY_STATE
+{
+    identities
+    {
+        A[ss] = 1;
+        r[ss] = 1 / beta - (1 - delta);
+        w[ss] = (1 - alpha) * (alpha / r[ss]) ^ (alpha / (1 - alpha));
+        Y[ss] = (r[ss] / (r[ss] - delta * alpha)) ^ (sigma_C / (sigma_C + sigma_L)) *
+                (w[ss] * (w[ss] / (1 - alpha)) ^ sigma_L) ^ (1 / (sigma_C + sigma_L));
+        I[ss] = delta * alpha / r[ss] * Y[ss];
+        C[ss] = ((1 - alpha) ^ (-sigma_L) * w[ss] ^ (1 + sigma_L)) ^ (1 / sigma_C) * Y[ss] ^ (-sigma_L / sigma_C);
+        K[ss] = alpha * Y[ss] / r[ss];
+        L[ss] = (1 - alpha) * Y[ss] / w[ss];
+        U[ss] = 1 / (1 - beta) * (C[ss] ^ (1 - sigma_C) / (1 - sigma_C) - L[ss] ^ (1 + sigma_L) / (1 + sigma_L));
+        lambda[ss] = C[ss] ^ (-sigma_C);
+        q[ss] = lambda[ss];
+        TC[ss] = -(w[ss] * L[ss] + r[ss] * K[ss]);
+        Y_obs[ss] = log(Y[ss]);
+        dY_obs[ss] = 0;
+    };
+};
+
+block HOUSEHOLD
+{
+    definitions
+    {
+		u[] = C[] ^ (1 - sigma_C) / (1 - sigma_C) -
+			  L[] ^ (1 + sigma_L) / (1 + sigma_L);
+    };
+    controls
+    {
+		K[], C[], L[], I[];
+    };
+    objective
+    {
+		U[] = u[] + beta * E[][U[1]];
+    };
+    constraints
+    {
+		C[] + I[] = w[] * L[] + r[] * K[-1] : lambda[];
+		K[] = (1 - delta) * K[-1] + I[] : q[];
+    };
+
+    calibration
+    {
+		beta = 0.985;
+		delta = 0.025;
+		sigma_C = 2;
+		sigma_L = 1.5;
+    };
+};
+
+
+block FIRM
+{
+	controls
+	{
+		K[-1], L[];
+	};
+
+    objective
+    {
+		TC[] = -(w[] * L[] + r[] * K[-1]);
+	};
+
+    constraints
+    {
+		Y[] = A[] * K[-1] ^ alpha * L[] ^ (1 - alpha) : P[];
+    };
+
+	identities
+	{
+		log(A[]) = rho_A * log(A[-1]) + epsilon_A[];
+		P[] = 1;
+	};
+
+	shocks
+	{
+		epsilon_A[];
+	};
+
+    calibration
+    {
+		alpha = 0.35;
+		rho_A = 0.95;
+    };
+};
+
+
+block OBSERVATION
+{
+	identities
+	{
+		Y_obs[] = log(Y[]);
+		dY_obs[] = log(Y[]) - log(Y[-1]);
+	};
+};

--- a/tests/model/test_statespace.py
+++ b/tests/model/test_statespace.py
@@ -1,7 +1,3 @@
-# The observation-equation Z battery uses uniform ``lambda ss, p: ...`` signatures so the
-# test harness can call every coefficient/intercept builder identically; not every lambda
-# uses both arguments.
-# ruff: noqa: ARG005
 import numpy as np
 import pandas as pd
 import pymc as pm
@@ -17,11 +13,12 @@ from tests._resources.cache_compiled_models import (
     load_and_cache_model,
     load_and_cache_statespace,
 )
+from tests.conftest import TEST_GCNS
 
 
 @pytest.fixture
 def rbc_statespace():
-    return statespace_from_gcn("tests/_resources/test_gcns/rbc_linearized.gcn", verbose=False)
+    return statespace_from_gcn(TEST_GCNS / "rbc_linearized.gcn", verbose=False)
 
 
 def _eval_augmented_matrices(ss_mod):
@@ -116,7 +113,7 @@ def test_backward_direct_solver_produces_finite_logp():
 
 @pytest.mark.filterwarnings("ignore:Provided data contains missing values and will be automatically imputed")
 def test_constant_params_excluded_from_prior_samples():
-    ss_mod = statespace_from_gcn("tests/_resources/test_gcns/rbc_linearized.gcn", verbose=False)
+    ss_mod = statespace_from_gcn(TEST_GCNS / "rbc_linearized.gcn", verbose=False)
     ss_mod.configure(
         observed_states=["Y", "C", "L"],
         measurement_error=["Y", "C", "L"],
@@ -140,7 +137,7 @@ def test_constant_params_excluded_from_prior_samples():
 
 
 def test_constant_params_auto_excludes_priorless_params():
-    ss_mod = statespace_from_gcn("tests/_resources/test_gcns/open_rbc.gcn", verbose=False)
+    ss_mod = statespace_from_gcn(TEST_GCNS / "open_rbc.gcn", verbose=False)
     ss_mod.configure(observed_states=["Y"], constant_params="auto", solver="scan_cycle_reduction", verbose=False)
 
     params_with_priors = set(ss_mod.param_priors.keys())
@@ -358,17 +355,18 @@ def test_first_and_last_aggregation_use_direct_selector(rbc_statespace, method):
     np.testing.assert_allclose(Z[0], expected_row)
 
 
-# ---------------------------------------------------------------------------
-# Observation intercept and observation-equation tests
-# ---------------------------------------------------------------------------
+# RBC with a non-trivial analytic steady state (Y_ss ≈ 3, etc.).
+NL_GCN = "rbc_2_block_ss.gcn"
 
-NL_GCN = "tests/_resources/test_gcns/rbc_2_block_ss.gcn"
+# Same RBC plus an OBSERVATION block carrying ``Y_obs = log(Y)`` and
+# ``dY_obs = log(Y) - log(Y[-1])`` as model identities — the "Dynare way" of
+# adding observed series, used as the observation-equation equivalence reference.
+OBS_EQ_GCN = "rbc_2_block_obs_eq.gcn"
 
 
 @pytest.fixture
 def rbc_nonlinear_ss():
-    """Fresh statespace for an RBC with non-trivial analytic SS (Y_ss ≈ 3, etc.)."""
-    return statespace_from_gcn(NL_GCN, verbose=False)
+    return statespace_from_gcn(TEST_GCNS / NL_GCN, verbose=False)
 
 
 def _eval_obs_pieces(ss_mod, param_values):
@@ -465,34 +463,6 @@ def test_ss_obs_intercept_unknown_state_raises(rbc_nonlinear_ss):
         )
 
 
-def test_observation_equations_trivial_matches_ss_obs_intercept():
-    """observation_equations={'Y': 'log(Y[])'} produces identical d/Z to ss_obs_intercept=['Y']."""
-    model = load_and_cache_model("rbc_2_block_ss.gcn")
-
-    ss_obs = statespace_from_gcn(NL_GCN, verbose=False)
-    ss_obs.configure(
-        observed_states=["Y"],
-        measurement_error=["Y"],
-        constant_params="auto",
-        ss_obs_intercept=["Y"],
-        verbose=False,
-    )
-    d_ssoi, Z_ssoi = _eval_obs_pieces(ss_obs, model.parameters())
-
-    obs_eq = statespace_from_gcn(NL_GCN, verbose=False)
-    obs_eq.configure(
-        observed_states=["Y"],
-        measurement_error=["Y"],
-        constant_params="auto",
-        observation_equations={"Y": "log(Y[])"},
-        verbose=False,
-    )
-    d_eq, Z_eq = _eval_obs_pieces(obs_eq, model.parameters())
-
-    np.testing.assert_allclose(d_ssoi, d_eq, rtol=1e-12)
-    np.testing.assert_allclose(Z_ssoi, Z_eq, rtol=1e-12)
-
-
 @pytest.mark.parametrize(
     "kwargs,exception,match",
     [
@@ -539,50 +509,9 @@ def test_observation_equations_validation_errors(rbc_nonlinear_ss, kwargs, excep
         )
 
 
-@pytest.mark.parametrize("method, intercept_scale", [("sum", 4.0), ("mean", 1.0)])
-def test_observation_equations_sum_aggregation_broadcasts_coefficients(method, intercept_scale):
-    """``sum`` / ``mean`` aggregation of an obs equation broadcasts each coefficient across the window.
-
-    For ``log(C[] + I[])`` aggregated over 4 quarters the design row gets a
-    contribution at each of the 4 lag depths (C and I current plus lags 1-3).
-    With ``sum``, each contribution carries the per-period coefficient
-    ``coeff``; with ``mean``, ``coeff / aggregation_period``.
-    """
-    ss_mod = statespace_from_gcn(NL_GCN, verbose=False)
-    ss_mod.configure(
-        observed_states=["Y_avg"],
-        measurement_error=["Y_avg"],
-        constant_params="auto",
-        observation_equations={"Y_avg": "log(C[] + I[])"},
-        temporal_aggregation={"Y_avg": method},
-        aggregation_period=4,
-        verbose=False,
-    )
-    assert ss_mod._obs_lag_depths == {"C": 3, "I": 3}
-
-    model, ss_vals = _model_ss_values("rbc_2_block_ss.gcn")
-    C_ss, I_ss = float(ss_vals["C_ss"]), float(ss_vals["I_ss"])
-    expected_intercept = intercept_scale * np.log(C_ss + I_ss)
-    per_period_coeff_C = C_ss / (C_ss + I_ss)
-    per_period_coeff_I = I_ss / (C_ss + I_ss)
-    weight = 1.0 if method == "sum" else 0.25
-
-    d, Z = _eval_obs_pieces(ss_mod, model.parameters())
-    np.testing.assert_allclose(d[0], expected_intercept, rtol=1e-10)
-
-    c_orig = ss_mod._orig_state_names.index("C")
-    i_orig = ss_mod._orig_state_names.index("I")
-    np.testing.assert_allclose(Z[0, c_orig], weight * per_period_coeff_C, rtol=1e-10)
-    np.testing.assert_allclose(Z[0, i_orig], weight * per_period_coeff_I, rtol=1e-10)
-    for k in range(1, 4):
-        np.testing.assert_allclose(Z[0, ss_mod._obs_lag_column("C", -k)], weight * per_period_coeff_C, rtol=1e-10)
-        np.testing.assert_allclose(Z[0, ss_mod._obs_lag_column("I", -k)], weight * per_period_coeff_I, rtol=1e-10)
-
-
 @pytest.mark.filterwarnings("ignore:Provided data contains missing values")
 def test_observation_equations_aggregation_produces_finite_logp():
-    """End-to-end Kalman log-likelihood evaluates finitely for an annual-summed quarterly obs eq."""
-    ss_mod = statespace_from_gcn(NL_GCN, verbose=False)
+    ss_mod = statespace_from_gcn(TEST_GCNS / NL_GCN, verbose=False)
     ss_mod.configure(
         observed_states=["dlog_Y_annual"],
         measurement_error=["dlog_Y_annual"],
@@ -607,51 +536,8 @@ def test_observation_equations_aggregation_produces_finite_logp():
     assert np.isfinite(logp)
 
 
-def test_observation_equations_lag_state_is_shift_companion(rbc_nonlinear_ss):
-    """The augmented transition row for the new lag state copies the parent variable's previous value."""
-    rbc_nonlinear_ss.configure(
-        observed_states=["Y"],
-        measurement_error=["Y"],
-        constant_params="auto",
-        observation_equations={"Y": "log(Y[]) - log(Y[-1])"},
-        verbose=False,
-    )
-    model = load_and_cache_model("rbc_2_block_ss.gcn")
-    inputs = [v for v in rbc_nonlinear_ss.input_parameters if v.name in model.parameters()]
-    fn = pytensor.function(inputs, rbc_nonlinear_ss.ssm["transition"], on_unused_input="ignore")
-    T_aug = fn(*[model.parameters()[v.name] for v in inputs])
-
-    y_idx = rbc_nonlinear_ss._orig_state_names.index("Y")
-    y_lag1 = rbc_nonlinear_ss._obs_lag_starts["Y"]
-    expected_row = np.zeros(T_aug.shape[1])
-    expected_row[y_idx] = 1.0
-    np.testing.assert_allclose(T_aug[y_lag1], expected_row)
-
-
-def test_observation_equations_with_lag_produces_finite_logp(rbc_nonlinear_ss):
-    """End-to-end: lag-dependent obs equation flows through to a finite Kalman likelihood."""
-    rbc_nonlinear_ss.configure(
-        observed_states=["Y"],
-        measurement_error=["Y"],
-        constant_params="auto",
-        observation_equations={"Y": "log(Y[]) - log(Y[-1])"},
-        verbose=False,
-    )
-    rng = np.random.default_rng(7)
-    n = 40
-    idx = pd.date_range("2000-01-01", periods=n, freq="QS")
-    data = pd.DataFrame(rng.normal(scale=0.05, size=(n, 1)), index=idx, columns=["Y"])
-    with pm.Model() as m:
-        rbc_nonlinear_ss.to_pymc()
-        pm.Gamma("sigma_epsilon_A", alpha=2, beta=100)
-        pm.Gamma("error_sigma_Y", alpha=2, beta=100)
-        rbc_nonlinear_ss.build_statespace_graph(data, add_norm_check=False)
-        logp = m.compile_logp()(m.initial_point())
-    assert np.isfinite(logp)
-
-
 def test_observation_equations_produce_finite_logp(rbc_nonlinear_ss):
-    """End-to-end: build statespace graph with an obs equation, evaluate logp."""
+    """Two simultaneous observation equations flow through to a finite Kalman likelihood."""
     rbc_nonlinear_ss.configure(
         observed_states=["Y", "C"],
         measurement_error=["Y", "C"],
@@ -673,9 +559,71 @@ def test_observation_equations_produce_finite_logp(rbc_nonlinear_ss):
     assert np.isfinite(logp)
 
 
-# ---------------------------------------------------------------------------
-# Battery: observation-equation Z matrix matches analytical expectation
-# ---------------------------------------------------------------------------
+def _obs_eq_logp(ss_mod, obs_name, data, point=None):
+    """Build the pymc statespace graph for ``ss_mod`` and return ``(logp, point)``.
+
+    The shock and measurement-error standard deviations get identical priors in
+    both representations, so reusing ``point`` across models evaluates the
+    log-likelihood at exactly the same parameter values.
+    """
+    with pm.Model() as m:
+        ss_mod.to_pymc()
+        pm.Gamma("sigma_epsilon_A", alpha=2, beta=100)
+        pm.Gamma(f"error_sigma_{obs_name}", alpha=2, beta=100)
+        ss_mod.build_statespace_graph(data, add_norm_check=False)
+        ip = m.initial_point() if point is None else point
+        logp = m.compile_logp()(ip)
+    return logp, ip
+
+
+@pytest.mark.parametrize(
+    "obs_name, obs_eq, ss_intercept",
+    [
+        pytest.param("Y_obs", "log(Y[])", True, id="contemporaneous"),
+        pytest.param("dY_obs", "log(Y[]) - log(Y[-1])", False, id="first_difference"),
+    ],
+)
+def test_observation_equation_matches_model_variable_equivalent(obs_name, obs_eq, ss_intercept):
+    """An observation equation gives the same Kalman likelihood as the "Dynare way".
+
+    The design-matrix feature linearizes ``obs_eq`` into ``Z`` (appending an
+    obs-lag block to ``T`` for any lagged terms). The reference gcn
+    ``rbc_2_block_obs_eq.gcn`` instead carries the series as a level-linearized
+    model identity observed through a plain selector. The two state-space
+    representations have different state dimensions but imply the same
+    distribution over the observable, so the log-likelihood must agree.
+    """
+    rng = np.random.default_rng(0)
+    n = 50
+    idx = pd.date_range("2000-01-01", periods=n, freq="QS")
+    center = np.log(3.0) if ss_intercept else 0.0
+    data = pd.DataFrame(center + rng.normal(scale=0.05, size=(n, 1)), index=idx, columns=[obs_name])
+
+    # Design-matrix way: observation equation on the plain model.
+    dm = statespace_from_gcn(TEST_GCNS / NL_GCN, verbose=False)
+    dm.configure(
+        observed_states=[obs_name],
+        measurement_error=[obs_name],
+        constant_params="auto",
+        observation_equations={obs_name: obs_eq},
+        verbose=False,
+    )
+    logp_dm, point = _obs_eq_logp(dm, obs_name, data)
+
+    # Dynare way: the series is a level-linearized model variable, plain selector.
+    dyn = statespace_from_gcn(TEST_GCNS / OBS_EQ_GCN, not_loglin_variables=["Y_obs", "dY_obs"], verbose=False)
+    dyn.configure(
+        observed_states=[obs_name],
+        measurement_error=[obs_name],
+        constant_params="auto",
+        ss_obs_intercept=[obs_name] if ss_intercept else None,
+        verbose=False,
+    )
+    logp_dyn, _ = _obs_eq_logp(dyn, obs_name, data, point=point)
+
+    # The obs-equation representation carries a leaner state vector.
+    assert dm.k_states < dyn.k_states
+    np.testing.assert_allclose(logp_dm, logp_dyn, rtol=1e-7, atol=1e-7)
 
 
 def _build_expected_Z(ss_mod, per_period_coeffs, agg_method, agg_period):
@@ -722,7 +670,7 @@ def _params_at_calib():
 # aggregation broadcasting; ``intercept_fn(ss, params)`` returns the per-period
 # intercept. The test helper does the broadcasting and the scaling.
 _BATTERY = [
-    # ---- No aggregation, contemporaneous only -------------------------------
+    # No aggregation, contemporaneous only
     pytest.param(
         "log(Y[])",
         lambda ss, p: {("Y", 0): 1.0},
@@ -771,7 +719,16 @@ _BATTERY = [
         {},
         id="intercept_with_parameter",
     ),
-    # ---- No aggregation, with lags ------------------------------------------
+    pytest.param(
+        "log(Y[]) - log(Y[ss])",
+        lambda ss, p: {("Y", 0): 1.0},
+        lambda ss, p: 0.0,
+        None,
+        1,
+        {},
+        id="steady_state_reference",
+    ),
+    # No aggregation, with lags
     pytest.param(
         "log(Y[]) - log(Y[-1])",
         lambda ss, p: {("Y", 0): 1.0, ("Y", -1): -1.0},
@@ -817,7 +774,7 @@ _BATTERY = [
         {"Y": 1},
         id="bgp_growth_rate_with_trend",
     ),
-    # ---- Aggregation broadcasting -------------------------------------------
+    # Aggregation broadcasting
     pytest.param(
         "log(Y[])",
         lambda ss, p: {("Y", 0): 1.0},
@@ -847,6 +804,30 @@ _BATTERY = [
         2,
         {"Y": 1, "C": 1},
         id="sum_agg_log_of_sum",
+    ),
+    pytest.param(
+        "log(C[] + I[])",
+        lambda ss, p: {
+            ("C", 0): ss["C"] / (ss["C"] + ss["I"]),
+            ("I", 0): ss["I"] / (ss["C"] + ss["I"]),
+        },
+        lambda ss, p: np.log(ss["C"] + ss["I"]),
+        "sum",
+        4,
+        {"C": 3, "I": 3},
+        id="sum_agg_two_variable_broadcast",
+    ),
+    pytest.param(
+        "log(C[] + I[])",
+        lambda ss, p: {
+            ("C", 0): ss["C"] / (ss["C"] + ss["I"]),
+            ("I", 0): ss["I"] / (ss["C"] + ss["I"]),
+        },
+        lambda ss, p: np.log(ss["C"] + ss["I"]),
+        "mean",
+        4,
+        {"C": 3, "I": 3},
+        id="mean_agg_two_variable_broadcast",
     ),
     pytest.param(
         "log(Y[]) - log(Y[-1])",
@@ -893,7 +874,7 @@ _BATTERY = [
         {"Y": 3},
         id="sum_agg_two_step_difference",
     ),
-    # ---- first / last aggregation: no broadcasting --------------------------
+    # first / last aggregation: no broadcasting
     pytest.param(
         "log(Y[]) - log(Y[-1])",
         lambda ss, p: {("Y", 0): 1.0, ("Y", -1): -1.0},
@@ -926,11 +907,9 @@ def test_observation_equation_Z_matches_analytical_expectation(
 ):
     """For a battery of obs equations, Z and the intercept match a hand-computed reference.
 
-    The reference is built by ``_build_expected_Z`` from per-period linearized
-    coefficients and is broadcast across the aggregation window exactly as
-    ``_make_design_matrix`` should. Any mismatch indicates a bug in the
-    framework's coefficient placement, lag-column indexing, broadcasting,
-    weighting, or scaling.
+    ``_build_expected_Z`` builds the reference from per-period linearized
+    coefficients, broadcast across the aggregation window the same way
+    ``_make_design_matrix`` does.
     """
     name = "y_obs"
     cfg = {
@@ -944,7 +923,7 @@ def test_observation_equation_Z_matches_analytical_expectation(
         cfg["temporal_aggregation"] = {name: agg}
         cfg["aggregation_period"] = period
 
-    ss_mod = statespace_from_gcn(NL_GCN, verbose=False)
+    ss_mod = statespace_from_gcn(TEST_GCNS / NL_GCN, verbose=False)
     ss_mod.configure(**cfg)
 
     assert ss_mod._obs_lag_depths == depths
@@ -962,14 +941,32 @@ def test_observation_equation_Z_matches_analytical_expectation(
     np.testing.assert_allclose(d[0], expected_d, rtol=1e-10, atol=1e-12)
 
 
-def test_multiple_obs_equations_share_lag_block_correctly():
-    """Two obs equations using overlapping lag depths share the same lag slots.
+def test_observation_equation_level_linearized_variable_coefficient():
+    r"""A level-linearized variable linearizes with the plain derivative — no ``v_ss`` chain-rule factor.
 
-    Eq1 needs ``Y[-1]``; Eq2 needs ``Y[-3]``. The framework should allocate the
-    deeper chain (depth 3) and route Eq1's lag-1 coefficient into the same Y
-    chain.
+    Every other obs-equation test uses log-linearized variables, where ``log(Y)`` has unit
+    coefficient. Here ``Y`` is level-linearized, so the state holds ``Y - Y_ss`` and the coefficient
+    of ``log(Y)`` is :math:`\\partial \\log Y / \\partial Y = 1 / Y_{ss}` — the ``else`` branch of
+    ``_linearize_observation_equation``.
     """
-    ss_mod = statespace_from_gcn(NL_GCN, verbose=False)
+    ss_mod = statespace_from_gcn(TEST_GCNS / NL_GCN, not_loglin_variables=["Y"], verbose=False)
+    ss_mod.configure(
+        observed_states=["y_obs"],
+        measurement_error=["y_obs"],
+        constant_params="auto",
+        observation_equations={"y_obs": "log(Y[])"},
+        verbose=False,
+    )
+    ss = _ss_floats()
+    d, Z = _eval_obs_pieces(ss_mod, _params_at_calib())
+    y_idx = ss_mod._orig_state_names.index("Y")
+    np.testing.assert_allclose(Z[0, y_idx], 1.0 / ss["Y"], rtol=1e-10)
+    np.testing.assert_allclose(d[0], np.log(ss["Y"]), rtol=1e-10)
+
+
+def test_multiple_obs_equations_share_lag_block_correctly():
+    """Two obs equations with overlapping lag depths share one lag chain, sized to the deeper one."""
+    ss_mod = statespace_from_gcn(TEST_GCNS / NL_GCN, verbose=False)
     ss_mod.configure(
         observed_states=["fast", "slow"],
         measurement_error=["fast", "slow"],
@@ -982,9 +979,7 @@ def test_multiple_obs_equations_share_lag_block_correctly():
     )
     assert ss_mod._obs_lag_depths == {"Y": 3}
 
-    ss = _ss_floats()
-    params = _params_at_calib()
-    d, Z = _eval_obs_pieces(ss_mod, params)
+    d, Z = _eval_obs_pieces(ss_mod, _params_at_calib())
 
     y_orig = ss_mod._orig_state_names.index("Y")
     y_lag1 = ss_mod._obs_lag_column("Y", -1)
@@ -1005,8 +1000,8 @@ def test_multiple_obs_equations_share_lag_block_correctly():
 
 
 def test_multiple_obs_equations_different_variables_independent_chains():
-    """Independent lag chains for different variables: each variable gets its own slot range."""
-    ss_mod = statespace_from_gcn(NL_GCN, verbose=False)
+    """Each variable referenced at a lag gets its own independent lag chain, with no cross-contamination."""
+    ss_mod = statespace_from_gcn(TEST_GCNS / NL_GCN, verbose=False)
     ss_mod.configure(
         observed_states=["Y_diff", "C_diff"],
         measurement_error=["Y_diff", "C_diff"],
@@ -1019,7 +1014,6 @@ def test_multiple_obs_equations_different_variables_independent_chains():
     )
     assert ss_mod._obs_lag_depths == {"Y": 1, "C": 2}
 
-    ss = _ss_floats()
     d, Z = _eval_obs_pieces(ss_mod, _params_at_calib())
     np.testing.assert_allclose(d, [0.0, 0.0], atol=1e-12)
 
@@ -1040,7 +1034,7 @@ def test_multiple_obs_equations_different_variables_independent_chains():
 
 def test_obs_equation_alongside_pure_selector_observation():
     """Mixing an obs-equation series with a pure-selector observation gives independent rows."""
-    ss_mod = statespace_from_gcn(NL_GCN, verbose=False)
+    ss_mod = statespace_from_gcn(TEST_GCNS / NL_GCN, verbose=False)
     ss_mod.configure(
         observed_states=["L", "Y_diff"],
         measurement_error=["L", "Y_diff"],
@@ -1049,7 +1043,6 @@ def test_obs_equation_alongside_pure_selector_observation():
         verbose=False,
     )
 
-    ss = _ss_floats()
     d, Z = _eval_obs_pieces(ss_mod, _params_at_calib())
 
     l_idx = ss_mod._orig_state_names.index("L")
@@ -1069,7 +1062,7 @@ def test_obs_equation_alongside_pure_selector_observation():
 
 def test_observation_equations_lag_states_have_zero_selection_rows():
     """Obs-eq lag states are deterministic shifts, so their rows of R are all zero."""
-    ss_mod = statespace_from_gcn(NL_GCN, verbose=False)
+    ss_mod = statespace_from_gcn(TEST_GCNS / NL_GCN, verbose=False)
     ss_mod.configure(
         observed_states=["Y_diff"],
         measurement_error=["Y_diff"],
@@ -1091,7 +1084,7 @@ def test_observation_equations_lag_chain_propagates_correctly():
     Catches off-by-one errors in ``_append_obs_lag_block``'s ``F_lag`` /
     ``C_lag`` construction that a static T-row inspection would miss.
     """
-    ss_mod = statespace_from_gcn(NL_GCN, verbose=False)
+    ss_mod = statespace_from_gcn(TEST_GCNS / NL_GCN, verbose=False)
     ss_mod.configure(
         observed_states=["dlog_Y"],
         measurement_error=["dlog_Y"],
@@ -1121,8 +1114,7 @@ def test_observation_equations_lag_chain_propagates_correctly():
 
 
 def test_observation_equation_simplifies_to_zero_produces_zero_row():
-    """An obs equation that simplifies to zero gets a zero design row and no lag slots allocated."""
-    ss_mod = statespace_from_gcn(NL_GCN, verbose=False)
+    ss_mod = statespace_from_gcn(TEST_GCNS / NL_GCN, verbose=False)
     ss_mod.configure(
         observed_states=["dummy"],
         measurement_error=["dummy"],
@@ -1147,7 +1139,7 @@ def test_observation_equations_carry_model_variable_assumptions():
     the raw time-t symbol in place, leading to ``MissingInputError`` when the
     Kalman likelihood was compiled.
     """
-    ss_mod = statespace_from_gcn("tests/_resources/test_gcns/open_rbc.gcn", verbose=False)
+    ss_mod = statespace_from_gcn(TEST_GCNS / "open_rbc.gcn", verbose=False)
     ss_mod.configure(
         observed_states=["Y_obs"],
         measurement_error=["Y_obs"],
@@ -1177,7 +1169,7 @@ def test_constant_params_baked_into_ss_obs_intercept():
     and the configure-time substitution only touched ``self._obs_equations``, leaving the SS-branch
     parameters as free graph inputs.
     """
-    ss_mod = statespace_from_gcn("tests/_resources/test_gcns/full_nk.gcn", verbose=False)
+    ss_mod = statespace_from_gcn(TEST_GCNS / "full_nk.gcn", verbose=False)
     ss_mod.configure(
         observed_states=["Y", "C", "L"],
         measurement_error=["Y", "C", "L"],
@@ -1193,13 +1185,14 @@ def test_constant_params_baked_into_ss_obs_intercept():
 
 
 def test_constant_params_baked_into_observation_equations():
-    """Parameters declared in ``constant_params`` are substituted as constants in obs-equation graphs.
+    """A ``constant_params`` parameter inside an observation equation is baked in, not left a free input.
 
-    Without the ``configure``-time ``graph_replace`` over ``self._obs_equations``, a parameter listed in
-    ``constant_params`` that appears in an observation equation would remain a free graph input — the
-    Kalman likelihood compile would then demand it as an unbound model parameter.
+    Without the ``configure``-time ``graph_replace`` over ``self._obs_equations``, the parameter would
+    remain a free graph input and the Kalman likelihood compile would demand it as an unbound model
+    parameter. The battery's ``intercept_with_parameter`` case covers the baked value; this checks the
+    obs-equation branch specifically does not leak it.
     """
-    ss_mod = statespace_from_gcn("tests/_resources/test_gcns/rbc_2_block_ss.gcn", verbose=False)
+    ss_mod = statespace_from_gcn(TEST_GCNS / NL_GCN, verbose=False)
     ss_mod.configure(
         observed_states=["Y"],
         measurement_error=["Y"],
@@ -1208,9 +1201,6 @@ def test_constant_params_baked_into_observation_equations():
         verbose=False,
     )
 
-    alpha_value = ss_mod.param_dict["alpha"]
-    obs_intercept = ss_mod.ssm["obs_intercept"]
-    alpha_leaves = [a for a in ancestors([obs_intercept]) if a.owner is None and a.name == "alpha"]
-    assert len(alpha_leaves) == 1
-    assert isinstance(alpha_leaves[0], TensorConstant)
-    np.testing.assert_allclose(alpha_leaves[0].data, alpha_value)
+    d = ss_mod.ssm["obs_intercept"]
+    free_leaves = {a.name for a in ancestors([d]) if a.owner is None and a.name and not isinstance(a, TensorConstant)}
+    assert "alpha" not in free_leaves

--- a/tests/model/test_statespace.py
+++ b/tests/model/test_statespace.py
@@ -1,8 +1,15 @@
+# The observation-equation Z battery uses uniform ``lambda ss, p: ...`` signatures so the
+# test harness can call every coefficient/intercept builder identically; not every lambda
+# uses both arguments.
+# ruff: noqa: ARG005
 import numpy as np
 import pandas as pd
 import pymc as pm
 import pytensor
 import pytest
+
+from pytensor.graph.traversal import ancestors
+from pytensor.tensor.variable import TensorConstant
 
 from gEconpy import statespace_from_gcn
 from gEconpy.model.statespace import data_from_prior, prepare_mixed_frequency_data
@@ -349,3 +356,861 @@ def test_first_and_last_aggregation_use_direct_selector(rbc_statespace, method):
     expected_row = np.zeros(rbc_statespace.k_states)
     expected_row[y_idx] = 1.0
     np.testing.assert_allclose(Z[0], expected_row)
+
+
+# ---------------------------------------------------------------------------
+# Observation intercept and observation-equation tests
+# ---------------------------------------------------------------------------
+
+NL_GCN = "tests/_resources/test_gcns/rbc_2_block_ss.gcn"
+
+
+@pytest.fixture
+def rbc_nonlinear_ss():
+    """Fresh statespace for an RBC with non-trivial analytic SS (Y_ss ≈ 3, etc.)."""
+    return statespace_from_gcn(NL_GCN, verbose=False)
+
+
+def _eval_obs_pieces(ss_mod, param_values):
+    """Compile and evaluate (obs_intercept, design) at the given parameter dict."""
+    inputs = [v for v in ss_mod.input_parameters if v.name in param_values]
+    fn = pytensor.function(
+        inputs,
+        [ss_mod.ssm["obs_intercept"], ss_mod.ssm["design"]],
+        on_unused_input="ignore",
+    )
+    return fn(*[param_values[v.name] for v in inputs])
+
+
+def _model_ss_values(gcn_file):
+    model = load_and_cache_model(gcn_file)
+    ss_vals = model.steady_state(verbose=False, progressbar=False)
+    return model, ss_vals
+
+
+def test_ss_obs_intercept_evaluates_to_log_v_ss(rbc_nonlinear_ss):
+    model, ss_vals = _model_ss_values("rbc_2_block_ss.gcn")
+    rbc_nonlinear_ss.configure(
+        observed_states=["Y", "C", "L"],
+        measurement_error=["Y", "C", "L"],
+        constant_params="auto",
+        ss_obs_intercept=["Y", "C", "L"],
+        verbose=False,
+    )
+    d, Z = _eval_obs_pieces(rbc_nonlinear_ss, model.parameters())
+
+    expected = np.array([np.log(float(ss_vals[f"{v}_ss"])) for v in ("Y", "C", "L")])
+    np.testing.assert_allclose(d, expected, rtol=1e-10)
+
+    for i, name in enumerate(("Y", "C", "L")):
+        idx = rbc_nonlinear_ss._orig_state_names.index(name)
+        np.testing.assert_allclose(Z[i, idx], 1.0)
+        np.testing.assert_allclose(Z[i].sum(), 1.0)
+
+
+def test_ss_obs_intercept_zero_for_unmentioned_states(rbc_nonlinear_ss):
+    model, ss_vals = _model_ss_values("rbc_2_block_ss.gcn")
+    rbc_nonlinear_ss.configure(
+        observed_states=["Y", "C"],
+        measurement_error=["Y", "C"],
+        constant_params="auto",
+        ss_obs_intercept=["Y"],
+        verbose=False,
+    )
+    d, _ = _eval_obs_pieces(rbc_nonlinear_ss, model.parameters())
+    assert d[0] == pytest.approx(np.log(float(ss_vals["Y_ss"])), rel=1e-10)
+    assert d[1] == 0.0
+
+
+def test_ss_obs_intercept_sum_aggregation_scales_intercept(rbc_nonlinear_ss):
+    model, ss_vals = _model_ss_values("rbc_2_block_ss.gcn")
+    rbc_nonlinear_ss.configure(
+        observed_states=["Y"],
+        measurement_error=["Y"],
+        constant_params="auto",
+        ss_obs_intercept=["Y"],
+        temporal_aggregation={"Y": "sum"},
+        aggregation_period=4,
+        verbose=False,
+    )
+    d, _ = _eval_obs_pieces(rbc_nonlinear_ss, model.parameters())
+    assert d[0] == pytest.approx(4 * np.log(float(ss_vals["Y_ss"])), rel=1e-10)
+
+
+def test_ss_obs_intercept_default_is_zero(rbc_nonlinear_ss):
+    """Omitting ``ss_obs_intercept`` leaves the framework's default zero obs_intercept in place."""
+    _model, _ = _model_ss_values("rbc_2_block_ss.gcn")
+    rbc_nonlinear_ss.configure(
+        observed_states=["Y"],
+        measurement_error=["Y"],
+        constant_params="auto",
+        verbose=False,
+    )
+    # obs_intercept slot is left at pymc_extras' default zero, so retrieving it
+    # via the public ssm getter returns the framework's default constant.
+    d = rbc_nonlinear_ss.ssm["obs_intercept"]
+    # pytensor compiles it to a vector of zeros at the right shape:
+    fn = pytensor.function([], d, on_unused_input="ignore")
+    np.testing.assert_allclose(fn(), np.zeros(rbc_nonlinear_ss.k_endog))
+
+
+def test_ss_obs_intercept_unknown_state_raises(rbc_nonlinear_ss):
+    with pytest.raises(ValueError, match="not in observed_states"):
+        rbc_nonlinear_ss.configure(
+            observed_states=["Y"],
+            measurement_error=["Y"],
+            constant_params="auto",
+            ss_obs_intercept=["NotObserved"],
+            verbose=False,
+        )
+
+
+def test_observation_equations_trivial_matches_ss_obs_intercept():
+    """observation_equations={'Y': 'log(Y[])'} produces identical d/Z to ss_obs_intercept=['Y']."""
+    model = load_and_cache_model("rbc_2_block_ss.gcn")
+
+    ss_obs = statespace_from_gcn(NL_GCN, verbose=False)
+    ss_obs.configure(
+        observed_states=["Y"],
+        measurement_error=["Y"],
+        constant_params="auto",
+        ss_obs_intercept=["Y"],
+        verbose=False,
+    )
+    d_ssoi, Z_ssoi = _eval_obs_pieces(ss_obs, model.parameters())
+
+    obs_eq = statespace_from_gcn(NL_GCN, verbose=False)
+    obs_eq.configure(
+        observed_states=["Y"],
+        measurement_error=["Y"],
+        constant_params="auto",
+        observation_equations={"Y": "log(Y[])"},
+        verbose=False,
+    )
+    d_eq, Z_eq = _eval_obs_pieces(obs_eq, model.parameters())
+
+    np.testing.assert_allclose(d_ssoi, d_eq, rtol=1e-12)
+    np.testing.assert_allclose(Z_ssoi, Z_eq, rtol=1e-12)
+
+
+@pytest.mark.parametrize(
+    "kwargs,exception,match",
+    [
+        pytest.param(
+            {"observation_equations": {"Y": "log(Y[])"}, "ss_obs_intercept": ["Y"]},
+            ValueError,
+            "appear in both observation_equations and ss_obs_intercept",
+            id="overlap_with_ss_obs_intercept",
+        ),
+        pytest.param(
+            {"observation_equations": {"NotObserved": "log(Y[])"}},
+            ValueError,
+            "not in observed_states",
+            id="key_not_in_observed_states",
+        ),
+        pytest.param(
+            {"observation_equations": {"Y": "log(NotAVariable[])"}},
+            ValueError,
+            "unknown model variable",
+            id="unknown_variable",
+        ),
+        pytest.param(
+            {"observation_equations": {"Y": "log(Y[]) + not_a_param"}},
+            ValueError,
+            "unknown symbol",
+            id="unknown_symbol",
+        ),
+        pytest.param(
+            {"observation_equations": {"Y": "log(Y[1])"}},
+            ValueError,
+            "lead reference",
+            id="lead_reference",
+        ),
+    ],
+)
+def test_observation_equations_validation_errors(rbc_nonlinear_ss, kwargs, exception, match):
+    with pytest.raises(exception, match=match):
+        rbc_nonlinear_ss.configure(
+            observed_states=["Y"],
+            measurement_error=["Y"],
+            constant_params="auto",
+            verbose=False,
+            **kwargs,
+        )
+
+
+@pytest.mark.parametrize("method, intercept_scale", [("sum", 4.0), ("mean", 1.0)])
+def test_observation_equations_sum_aggregation_broadcasts_coefficients(method, intercept_scale):
+    """``sum`` / ``mean`` aggregation of an obs equation broadcasts each coefficient across the window.
+
+    For ``log(C[] + I[])`` aggregated over 4 quarters the design row gets a
+    contribution at each of the 4 lag depths (C and I current plus lags 1-3).
+    With ``sum``, each contribution carries the per-period coefficient
+    ``coeff``; with ``mean``, ``coeff / aggregation_period``.
+    """
+    ss_mod = statespace_from_gcn(NL_GCN, verbose=False)
+    ss_mod.configure(
+        observed_states=["Y_avg"],
+        measurement_error=["Y_avg"],
+        constant_params="auto",
+        observation_equations={"Y_avg": "log(C[] + I[])"},
+        temporal_aggregation={"Y_avg": method},
+        aggregation_period=4,
+        verbose=False,
+    )
+    assert ss_mod._obs_lag_depths == {"C": 3, "I": 3}
+
+    model, ss_vals = _model_ss_values("rbc_2_block_ss.gcn")
+    C_ss, I_ss = float(ss_vals["C_ss"]), float(ss_vals["I_ss"])
+    expected_intercept = intercept_scale * np.log(C_ss + I_ss)
+    per_period_coeff_C = C_ss / (C_ss + I_ss)
+    per_period_coeff_I = I_ss / (C_ss + I_ss)
+    weight = 1.0 if method == "sum" else 0.25
+
+    d, Z = _eval_obs_pieces(ss_mod, model.parameters())
+    np.testing.assert_allclose(d[0], expected_intercept, rtol=1e-10)
+
+    c_orig = ss_mod._orig_state_names.index("C")
+    i_orig = ss_mod._orig_state_names.index("I")
+    np.testing.assert_allclose(Z[0, c_orig], weight * per_period_coeff_C, rtol=1e-10)
+    np.testing.assert_allclose(Z[0, i_orig], weight * per_period_coeff_I, rtol=1e-10)
+    for k in range(1, 4):
+        np.testing.assert_allclose(Z[0, ss_mod._obs_lag_column("C", -k)], weight * per_period_coeff_C, rtol=1e-10)
+        np.testing.assert_allclose(Z[0, ss_mod._obs_lag_column("I", -k)], weight * per_period_coeff_I, rtol=1e-10)
+
+
+@pytest.mark.filterwarnings("ignore:Provided data contains missing values")
+def test_observation_equations_aggregation_produces_finite_logp():
+    """End-to-end Kalman log-likelihood evaluates finitely for an annual-summed quarterly obs eq."""
+    ss_mod = statespace_from_gcn(NL_GCN, verbose=False)
+    ss_mod.configure(
+        observed_states=["dlog_Y_annual"],
+        measurement_error=["dlog_Y_annual"],
+        constant_params="auto",
+        observation_equations={"dlog_Y_annual": "log(Y[]) - log(Y[-1])"},
+        temporal_aggregation={"dlog_Y_annual": "sum"},
+        aggregation_period=4,
+        verbose=False,
+    )
+    rng = np.random.default_rng(11)
+    n = 32
+    idx = pd.date_range("2000-01-01", periods=n, freq="QS")
+    data = pd.DataFrame(np.nan, index=idx, columns=["dlog_Y_annual"])
+    # Annual observations land at the last quarter of each year.
+    data.iloc[3::4, 0] = rng.normal(scale=0.02, size=n // 4)
+    with pm.Model() as m:
+        ss_mod.to_pymc()
+        pm.Gamma("sigma_epsilon_A", alpha=2, beta=100)
+        pm.Gamma("error_sigma_dlog_Y_annual", alpha=2, beta=100)
+        ss_mod.build_statespace_graph(data, add_norm_check=False, missing_fill_value=-9999.0)
+        logp = m.compile_logp()(m.initial_point())
+    assert np.isfinite(logp)
+
+
+def test_observation_equations_lag_state_is_shift_companion(rbc_nonlinear_ss):
+    """The augmented transition row for the new lag state copies the parent variable's previous value."""
+    rbc_nonlinear_ss.configure(
+        observed_states=["Y"],
+        measurement_error=["Y"],
+        constant_params="auto",
+        observation_equations={"Y": "log(Y[]) - log(Y[-1])"},
+        verbose=False,
+    )
+    model = load_and_cache_model("rbc_2_block_ss.gcn")
+    inputs = [v for v in rbc_nonlinear_ss.input_parameters if v.name in model.parameters()]
+    fn = pytensor.function(inputs, rbc_nonlinear_ss.ssm["transition"], on_unused_input="ignore")
+    T_aug = fn(*[model.parameters()[v.name] for v in inputs])
+
+    y_idx = rbc_nonlinear_ss._orig_state_names.index("Y")
+    y_lag1 = rbc_nonlinear_ss._obs_lag_starts["Y"]
+    expected_row = np.zeros(T_aug.shape[1])
+    expected_row[y_idx] = 1.0
+    np.testing.assert_allclose(T_aug[y_lag1], expected_row)
+
+
+def test_observation_equations_with_lag_produces_finite_logp(rbc_nonlinear_ss):
+    """End-to-end: lag-dependent obs equation flows through to a finite Kalman likelihood."""
+    rbc_nonlinear_ss.configure(
+        observed_states=["Y"],
+        measurement_error=["Y"],
+        constant_params="auto",
+        observation_equations={"Y": "log(Y[]) - log(Y[-1])"},
+        verbose=False,
+    )
+    rng = np.random.default_rng(7)
+    n = 40
+    idx = pd.date_range("2000-01-01", periods=n, freq="QS")
+    data = pd.DataFrame(rng.normal(scale=0.05, size=(n, 1)), index=idx, columns=["Y"])
+    with pm.Model() as m:
+        rbc_nonlinear_ss.to_pymc()
+        pm.Gamma("sigma_epsilon_A", alpha=2, beta=100)
+        pm.Gamma("error_sigma_Y", alpha=2, beta=100)
+        rbc_nonlinear_ss.build_statespace_graph(data, add_norm_check=False)
+        logp = m.compile_logp()(m.initial_point())
+    assert np.isfinite(logp)
+
+
+def test_observation_equations_produce_finite_logp(rbc_nonlinear_ss):
+    """End-to-end: build statespace graph with an obs equation, evaluate logp."""
+    rbc_nonlinear_ss.configure(
+        observed_states=["Y", "C"],
+        measurement_error=["Y", "C"],
+        constant_params="auto",
+        observation_equations={"Y": "log(C[] + I[])", "C": "log(C[])"},
+        verbose=False,
+    )
+    rng = np.random.default_rng(42)
+    n = 30
+    idx = pd.date_range("2000-01-01", periods=n, freq="QS")
+    data = pd.DataFrame(rng.normal(scale=0.1, size=(n, 2)), index=idx, columns=["Y", "C"])
+    with pm.Model() as m:
+        rbc_nonlinear_ss.to_pymc()
+        pm.Gamma("sigma_epsilon_A", alpha=2, beta=100)
+        pm.Gamma("error_sigma_Y", alpha=2, beta=100)
+        pm.Gamma("error_sigma_C", alpha=2, beta=100)
+        rbc_nonlinear_ss.build_statespace_graph(data, add_norm_check=False)
+        logp = m.compile_logp()(m.initial_point())
+    assert np.isfinite(logp)
+
+
+# ---------------------------------------------------------------------------
+# Battery: observation-equation Z matrix matches analytical expectation
+# ---------------------------------------------------------------------------
+
+
+def _build_expected_Z(ss_mod, per_period_coeffs, agg_method, agg_period):
+    """Broadcast per-period coefficients across the aggregation window.
+
+    Mirrors what ``_make_design_matrix`` should do. Returns a ``(k_endog,
+    k_states)`` numpy array with the obs-equation row populated.
+    """
+    Z = np.zeros((ss_mod.k_endog, ss_mod.k_states))
+    if agg_method == "sum":
+        n_periods, weight = agg_period, 1.0
+    elif agg_method == "mean":
+        n_periods, weight = agg_period, 1.0 / agg_period
+    else:
+        n_periods, weight = 1, 1.0
+
+    for (vname, lag), coeff in per_period_coeffs.items():
+        for d in range(n_periods):
+            effective_lag = lag - d
+            col = (
+                ss_mod._orig_state_names.index(vname)
+                if effective_lag == 0
+                else ss_mod._obs_lag_column(vname, effective_lag)
+            )
+            Z[0, col] += weight * coeff
+    return Z
+
+
+def _expected_intercept(base, agg_method, agg_period):
+    return agg_period * base if agg_method == "sum" else base
+
+
+def _ss_floats():
+    ss = load_and_cache_model("rbc_2_block_ss.gcn").steady_state(verbose=False, progressbar=False)
+    return {key.removesuffix("_ss"): float(val) for key, val in ss.items()}
+
+
+def _params_at_calib():
+    return load_and_cache_model("rbc_2_block_ss.gcn").parameters()
+
+
+# Each parametrize entry is (eq_string, coeffs_fn, intercept_fn, agg, period, expected_depths).
+# ``coeffs_fn(ss, params)`` returns the per-period linearized coefficients before any
+# aggregation broadcasting; ``intercept_fn(ss, params)`` returns the per-period
+# intercept. The test helper does the broadcasting and the scaling.
+_BATTERY = [
+    # ---- No aggregation, contemporaneous only -------------------------------
+    pytest.param(
+        "log(Y[])",
+        lambda ss, p: {("Y", 0): 1.0},
+        lambda ss, p: np.log(ss["Y"]),
+        None,
+        1,
+        {},
+        id="trivial_log_Y",
+    ),
+    pytest.param(
+        "2 * log(Y[])",
+        lambda ss, p: {("Y", 0): 2.0},
+        lambda ss, p: 2.0 * np.log(ss["Y"]),
+        None,
+        1,
+        {},
+        id="scaled_log_Y",
+    ),
+    pytest.param(
+        "log(Y[]) - log(C[])",
+        lambda ss, p: {("Y", 0): 1.0, ("C", 0): -1.0},
+        lambda ss, p: np.log(ss["Y"]) - np.log(ss["C"]),
+        None,
+        1,
+        {},
+        id="log_ratio_Y_over_C",
+    ),
+    pytest.param(
+        "log(Y[] + C[])",
+        lambda ss, p: {
+            ("Y", 0): ss["Y"] / (ss["Y"] + ss["C"]),
+            ("C", 0): ss["C"] / (ss["Y"] + ss["C"]),
+        },
+        lambda ss, p: np.log(ss["Y"] + ss["C"]),
+        None,
+        1,
+        {},
+        id="log_of_sum",
+    ),
+    pytest.param(
+        "log(Y[]) + alpha",
+        lambda ss, p: {("Y", 0): 1.0},
+        lambda ss, p: np.log(ss["Y"]) + p["alpha"],
+        None,
+        1,
+        {},
+        id="intercept_with_parameter",
+    ),
+    # ---- No aggregation, with lags ------------------------------------------
+    pytest.param(
+        "log(Y[]) - log(Y[-1])",
+        lambda ss, p: {("Y", 0): 1.0, ("Y", -1): -1.0},
+        lambda ss, p: 0.0,
+        None,
+        1,
+        {"Y": 1},
+        id="first_difference_Y",
+    ),
+    pytest.param(
+        "log(Y[-1])",
+        lambda ss, p: {("Y", -1): 1.0},
+        lambda ss, p: np.log(ss["Y"]),
+        None,
+        1,
+        {"Y": 1},
+        id="lag_only_no_current",
+    ),
+    pytest.param(
+        "log(Y[]) - log(Y[-2])",
+        lambda ss, p: {("Y", 0): 1.0, ("Y", -2): -1.0},
+        lambda ss, p: 0.0,
+        None,
+        1,
+        {"Y": 2},
+        id="depth_2_difference",
+    ),
+    pytest.param(
+        "log(Y[]) - 2 * log(Y[-1]) + log(Y[-2])",
+        lambda ss, p: {("Y", 0): 1.0, ("Y", -1): -2.0, ("Y", -2): 1.0},
+        lambda ss, p: 0.0,
+        None,
+        1,
+        {"Y": 2},
+        id="second_difference",
+    ),
+    pytest.param(
+        "log(Y[]) - log(Y[-1]) + log(A[])",
+        lambda ss, p: {("Y", 0): 1.0, ("Y", -1): -1.0, ("A", 0): 1.0},
+        lambda ss, p: np.log(ss["A"]),
+        None,
+        1,
+        {"Y": 1},
+        id="bgp_growth_rate_with_trend",
+    ),
+    # ---- Aggregation broadcasting -------------------------------------------
+    pytest.param(
+        "log(Y[])",
+        lambda ss, p: {("Y", 0): 1.0},
+        lambda ss, p: np.log(ss["Y"]),
+        "sum",
+        4,
+        {"Y": 3},
+        id="sum_agg_contemporaneous",
+    ),
+    pytest.param(
+        "log(Y[])",
+        lambda ss, p: {("Y", 0): 1.0},
+        lambda ss, p: np.log(ss["Y"]),
+        "mean",
+        4,
+        {"Y": 3},
+        id="mean_agg_contemporaneous",
+    ),
+    pytest.param(
+        "log(Y[] + C[])",
+        lambda ss, p: {
+            ("Y", 0): ss["Y"] / (ss["Y"] + ss["C"]),
+            ("C", 0): ss["C"] / (ss["Y"] + ss["C"]),
+        },
+        lambda ss, p: np.log(ss["Y"] + ss["C"]),
+        "sum",
+        2,
+        {"Y": 1, "C": 1},
+        id="sum_agg_log_of_sum",
+    ),
+    pytest.param(
+        "log(Y[]) - log(Y[-1])",
+        lambda ss, p: {("Y", 0): 1.0, ("Y", -1): -1.0},
+        lambda ss, p: 0.0,
+        "sum",
+        4,
+        {"Y": 4},
+        id="sum_agg_first_difference_telescopes_4",
+    ),
+    pytest.param(
+        "log(Y[]) - log(Y[-1])",
+        lambda ss, p: {("Y", 0): 1.0, ("Y", -1): -1.0},
+        lambda ss, p: 0.0,
+        "sum",
+        2,
+        {"Y": 2},
+        id="sum_agg_first_difference_telescopes_2",
+    ),
+    pytest.param(
+        "log(Y[]) - log(Y[-1])",
+        lambda ss, p: {("Y", 0): 1.0, ("Y", -1): -1.0},
+        lambda ss, p: 0.0,
+        "mean",
+        4,
+        {"Y": 4},
+        id="mean_agg_first_difference_telescopes",
+    ),
+    pytest.param(
+        "log(Y[-1])",
+        lambda ss, p: {("Y", -1): 1.0},
+        lambda ss, p: np.log(ss["Y"]),
+        "sum",
+        3,
+        {"Y": 3},
+        id="sum_agg_lag_only",
+    ),
+    pytest.param(
+        "log(Y[]) - log(Y[-2])",
+        lambda ss, p: {("Y", 0): 1.0, ("Y", -2): -1.0},
+        lambda ss, p: 0.0,
+        "sum",
+        2,
+        {"Y": 3},
+        id="sum_agg_two_step_difference",
+    ),
+    # ---- first / last aggregation: no broadcasting --------------------------
+    pytest.param(
+        "log(Y[]) - log(Y[-1])",
+        lambda ss, p: {("Y", 0): 1.0, ("Y", -1): -1.0},
+        lambda ss, p: 0.0,
+        "last",
+        4,
+        {"Y": 1},
+        id="last_agg_first_difference",
+    ),
+    pytest.param(
+        "log(Y[])",
+        lambda ss, p: {("Y", 0): 1.0},
+        lambda ss, p: np.log(ss["Y"]),
+        "first",
+        4,
+        {},
+        id="first_agg_contemporaneous",
+    ),
+]
+
+
+@pytest.mark.parametrize("obs_eq, coeffs_fn, intercept_fn, agg, period, depths", _BATTERY)
+def test_observation_equation_Z_matches_analytical_expectation(
+    obs_eq,
+    coeffs_fn,
+    intercept_fn,
+    agg,
+    period,
+    depths,
+):
+    """For a battery of obs equations, Z and the intercept match a hand-computed reference.
+
+    The reference is built by ``_build_expected_Z`` from per-period linearized
+    coefficients and is broadcast across the aggregation window exactly as
+    ``_make_design_matrix`` should. Any mismatch indicates a bug in the
+    framework's coefficient placement, lag-column indexing, broadcasting,
+    weighting, or scaling.
+    """
+    name = "y_obs"
+    cfg = {
+        "observed_states": [name],
+        "measurement_error": [name],
+        "constant_params": "auto",
+        "observation_equations": {name: obs_eq},
+        "verbose": False,
+    }
+    if agg is not None:
+        cfg["temporal_aggregation"] = {name: agg}
+        cfg["aggregation_period"] = period
+
+    ss_mod = statespace_from_gcn(NL_GCN, verbose=False)
+    ss_mod.configure(**cfg)
+
+    assert ss_mod._obs_lag_depths == depths
+
+    ss = _ss_floats()
+    params = _params_at_calib()
+    per_period_coeffs = coeffs_fn(ss, params)
+    per_period_intercept = float(intercept_fn(ss, params))
+
+    expected_Z = _build_expected_Z(ss_mod, per_period_coeffs, agg, period)
+    expected_d = _expected_intercept(per_period_intercept, agg, period)
+
+    d, Z = _eval_obs_pieces(ss_mod, params)
+    np.testing.assert_allclose(Z, expected_Z, rtol=1e-10, atol=1e-12)
+    np.testing.assert_allclose(d[0], expected_d, rtol=1e-10, atol=1e-12)
+
+
+def test_multiple_obs_equations_share_lag_block_correctly():
+    """Two obs equations using overlapping lag depths share the same lag slots.
+
+    Eq1 needs ``Y[-1]``; Eq2 needs ``Y[-3]``. The framework should allocate the
+    deeper chain (depth 3) and route Eq1's lag-1 coefficient into the same Y
+    chain.
+    """
+    ss_mod = statespace_from_gcn(NL_GCN, verbose=False)
+    ss_mod.configure(
+        observed_states=["fast", "slow"],
+        measurement_error=["fast", "slow"],
+        constant_params="auto",
+        observation_equations={
+            "fast": "log(Y[]) - log(Y[-1])",
+            "slow": "log(Y[]) - log(Y[-3])",
+        },
+        verbose=False,
+    )
+    assert ss_mod._obs_lag_depths == {"Y": 3}
+
+    ss = _ss_floats()
+    params = _params_at_calib()
+    d, Z = _eval_obs_pieces(ss_mod, params)
+
+    y_orig = ss_mod._orig_state_names.index("Y")
+    y_lag1 = ss_mod._obs_lag_column("Y", -1)
+    y_lag2 = ss_mod._obs_lag_column("Y", -2)
+    y_lag3 = ss_mod._obs_lag_column("Y", -3)
+
+    # ``fast`` row: +1 on Y, -1 on lag1, zero on lag2, lag3.
+    np.testing.assert_allclose(Z[0, y_orig], 1.0)
+    np.testing.assert_allclose(Z[0, y_lag1], -1.0)
+    np.testing.assert_allclose(Z[0, y_lag2], 0.0)
+    np.testing.assert_allclose(Z[0, y_lag3], 0.0)
+    # ``slow`` row: +1 on Y, zero on lag1, lag2, -1 on lag3.
+    np.testing.assert_allclose(Z[1, y_orig], 1.0)
+    np.testing.assert_allclose(Z[1, y_lag1], 0.0)
+    np.testing.assert_allclose(Z[1, y_lag2], 0.0)
+    np.testing.assert_allclose(Z[1, y_lag3], -1.0)
+    np.testing.assert_allclose(d, [0.0, 0.0], atol=1e-12)
+
+
+def test_multiple_obs_equations_different_variables_independent_chains():
+    """Independent lag chains for different variables: each variable gets its own slot range."""
+    ss_mod = statespace_from_gcn(NL_GCN, verbose=False)
+    ss_mod.configure(
+        observed_states=["Y_diff", "C_diff"],
+        measurement_error=["Y_diff", "C_diff"],
+        constant_params="auto",
+        observation_equations={
+            "Y_diff": "log(Y[]) - log(Y[-1])",
+            "C_diff": "log(C[]) - log(C[-2])",
+        },
+        verbose=False,
+    )
+    assert ss_mod._obs_lag_depths == {"Y": 1, "C": 2}
+
+    ss = _ss_floats()
+    d, Z = _eval_obs_pieces(ss_mod, _params_at_calib())
+    np.testing.assert_allclose(d, [0.0, 0.0], atol=1e-12)
+
+    y_orig = ss_mod._orig_state_names.index("Y")
+    c_orig = ss_mod._orig_state_names.index("C")
+
+    np.testing.assert_allclose(Z[0, y_orig], 1.0)
+    np.testing.assert_allclose(Z[0, ss_mod._obs_lag_column("Y", -1)], -1.0)
+    np.testing.assert_allclose(Z[1, c_orig], 1.0)
+    np.testing.assert_allclose(Z[1, ss_mod._obs_lag_column("C", -2)], -1.0)
+    np.testing.assert_allclose(Z[1, ss_mod._obs_lag_column("C", -1)], 0.0)
+
+    # No cross-contamination: Y's lag slot doesn't appear in C's row, vice versa.
+    np.testing.assert_allclose(Z[0, ss_mod._obs_lag_column("C", -1)], 0.0)
+    np.testing.assert_allclose(Z[0, ss_mod._obs_lag_column("C", -2)], 0.0)
+    np.testing.assert_allclose(Z[1, ss_mod._obs_lag_column("Y", -1)], 0.0)
+
+
+def test_obs_equation_alongside_pure_selector_observation():
+    """Mixing an obs-equation series with a pure-selector observation gives independent rows."""
+    ss_mod = statespace_from_gcn(NL_GCN, verbose=False)
+    ss_mod.configure(
+        observed_states=["L", "Y_diff"],
+        measurement_error=["L", "Y_diff"],
+        constant_params="auto",
+        observation_equations={"Y_diff": "log(Y[]) - log(Y[-1])"},
+        verbose=False,
+    )
+
+    ss = _ss_floats()
+    d, Z = _eval_obs_pieces(ss_mod, _params_at_calib())
+
+    l_idx = ss_mod._orig_state_names.index("L")
+    y_idx = ss_mod._orig_state_names.index("Y")
+    y_lag1 = ss_mod._obs_lag_column("Y", -1)
+
+    # Selector row for L: identity selector, zero intercept.
+    np.testing.assert_allclose(Z[0, l_idx], 1.0)
+    np.testing.assert_allclose(Z[0].sum(), 1.0)  # only L contributes
+    np.testing.assert_allclose(d[0], 0.0, atol=1e-12)
+
+    # Obs-equation row for Y_diff: +1 on Y, -1 on Y_lag1.
+    np.testing.assert_allclose(Z[1, y_idx], 1.0)
+    np.testing.assert_allclose(Z[1, y_lag1], -1.0)
+    np.testing.assert_allclose(d[1], 0.0, atol=1e-12)
+
+
+def test_observation_equations_lag_states_have_zero_selection_rows():
+    """Obs-eq lag states are deterministic shifts, so their rows of R are all zero."""
+    ss_mod = statespace_from_gcn(NL_GCN, verbose=False)
+    ss_mod.configure(
+        observed_states=["Y_diff"],
+        measurement_error=["Y_diff"],
+        constant_params="auto",
+        observation_equations={"Y_diff": "log(Y[]) - log(Y[-1])"},
+        verbose=False,
+    )
+    model = load_and_cache_model("rbc_2_block_ss.gcn")
+    inputs = [v for v in ss_mod.input_parameters if v.name in model.parameters()]
+    fn = pytensor.function(inputs, ss_mod.ssm["selection"], on_unused_input="ignore")
+    R_aug = fn(*[model.parameters()[v.name] for v in inputs])
+    y_lag1 = ss_mod._obs_lag_starts["Y"]
+    np.testing.assert_allclose(R_aug[y_lag1], 0.0)
+
+
+def test_observation_equations_lag_chain_propagates_correctly():
+    """Simulating the augmented dynamics: lag-k slot should hold the parent variable from k steps ago.
+
+    Catches off-by-one errors in ``_append_obs_lag_block``'s ``F_lag`` /
+    ``C_lag`` construction that a static T-row inspection would miss.
+    """
+    ss_mod = statespace_from_gcn(NL_GCN, verbose=False)
+    ss_mod.configure(
+        observed_states=["dlog_Y"],
+        measurement_error=["dlog_Y"],
+        constant_params="auto",
+        observation_equations={"dlog_Y": "log(Y[]) - log(Y[-3])"},
+        verbose=False,
+    )
+    model = load_and_cache_model("rbc_2_block_ss.gcn")
+    inputs = [v for v in ss_mod.input_parameters if v.name in model.parameters()]
+    T_aug = pytensor.function(inputs, ss_mod.ssm["transition"], on_unused_input="ignore")(
+        *[model.parameters()[v.name] for v in inputs]
+    )
+
+    rng = np.random.default_rng(0)
+    x = np.zeros(T_aug.shape[0])
+    x[: ss_mod._k_orig_states] = rng.normal(0, 0.1, size=ss_mod._k_orig_states)
+
+    y_orig = ss_mod._orig_state_names.index("Y")
+    history_Y = [x[y_orig]]
+    for _ in range(4):
+        x = T_aug @ x
+        history_Y.append(x[y_orig])
+
+    # After 4 steps, lag-1/2/3 slots should hold Y from 1, 2, 3 steps ago.
+    for k in range(1, 4):
+        np.testing.assert_allclose(x[ss_mod._obs_lag_column("Y", -k)], history_Y[-1 - k], rtol=1e-10)
+
+
+def test_observation_equation_simplifies_to_zero_produces_zero_row():
+    """An obs equation that simplifies to zero gets a zero design row and no lag slots allocated."""
+    ss_mod = statespace_from_gcn(NL_GCN, verbose=False)
+    ss_mod.configure(
+        observed_states=["dummy"],
+        measurement_error=["dummy"],
+        constant_params="auto",
+        observation_equations={"dummy": "log(Y[]) - log(Y[])"},
+        verbose=False,
+    )
+    assert ss_mod._obs_lag_depths == {}
+
+    d, Z = _eval_obs_pieces(ss_mod, load_and_cache_model("rbc_2_block_ss.gcn").parameters())
+    np.testing.assert_allclose(d[0], 0.0, atol=1e-12)
+    np.testing.assert_allclose(Z[0], 0.0, atol=1e-12)
+
+
+def test_observation_equations_carry_model_variable_assumptions():
+    """Obs equations on a model whose variables have ``positive`` assumptions linearize correctly.
+
+    Regression test for a bug where ``_parse_observation_equation`` called
+    ``ast_to_sympy`` without forwarding the model's per-variable assumptions.
+    Sympy equality includes assumptions, so the parsed ``v[]`` did not match
+    ``self.variables[i]`` and the linearization's ``xreplace`` silently left
+    the raw time-t symbol in place, leading to ``MissingInputError`` when the
+    Kalman likelihood was compiled.
+    """
+    ss_mod = statespace_from_gcn("tests/_resources/test_gcns/open_rbc.gcn", verbose=False)
+    ss_mod.configure(
+        observed_states=["Y_obs"],
+        measurement_error=["Y_obs"],
+        constant_params="auto",
+        observation_equations={"Y_obs": "log(Y[])"},
+        verbose=False,
+    )
+    # Evaluating the intercept fails with MissingInputError if any TimeAwareSymbol
+    # at time t leaked through unsubstituted.
+    model = load_and_cache_model("open_rbc.gcn")
+    inputs = [v for v in ss_mod.input_parameters if v.name in model.parameters()]
+    fn = pytensor.function(inputs, ss_mod.ssm["obs_intercept"], on_unused_input="ignore")
+    d = fn(*[model.parameters()[v.name] for v in inputs])
+    Y_ss = float(model.steady_state(verbose=False, progressbar=False)["Y_ss"])
+    np.testing.assert_allclose(d[0], np.log(Y_ss), rtol=1e-10)
+
+
+def test_constant_params_baked_into_ss_obs_intercept():
+    """Constant params bake into the ``ss_obs_intercept`` SS-expression branch.
+
+    Parameters declared in ``constant_params`` are substituted as constants
+    when a variable's intercept comes from the ``ss_obs_intercept``
+    SS-expression branch (not from an obs equation).
+
+    Regression test for a bug where ``_make_obs_intercept`` read ``self.steady_state_mapping``
+    directly for ``ss_obs_intercept`` variables; those SS graphs are in free parameter placeholders
+    and the configure-time substitution only touched ``self._obs_equations``, leaving the SS-branch
+    parameters as free graph inputs.
+    """
+    ss_mod = statespace_from_gcn("tests/_resources/test_gcns/full_nk.gcn", verbose=False)
+    ss_mod.configure(
+        observed_states=["Y", "C", "L"],
+        measurement_error=["Y", "C", "L"],
+        constant_params=[p for p in ss_mod.param_dict if p not in ss_mod.param_priors],
+        ss_obs_intercept=["L"],
+        verbose=False,
+    )
+
+    d = ss_mod.ssm["obs_intercept"]
+    free_leaves = {a.name for a in ancestors([d]) if a.owner is None and a.name and not isinstance(a, TensorConstant)}
+    leaked = free_leaves & set(ss_mod.constant_parameters)
+    assert not leaked, f"Constant params leaked as free inputs of obs_intercept: {sorted(leaked)}"
+
+
+def test_constant_params_baked_into_observation_equations():
+    """Parameters declared in ``constant_params`` are substituted as constants in obs-equation graphs.
+
+    Without the ``configure``-time ``graph_replace`` over ``self._obs_equations``, a parameter listed in
+    ``constant_params`` that appears in an observation equation would remain a free graph input — the
+    Kalman likelihood compile would then demand it as an unbound model parameter.
+    """
+    ss_mod = statespace_from_gcn("tests/_resources/test_gcns/rbc_2_block_ss.gcn", verbose=False)
+    ss_mod.configure(
+        observed_states=["Y"],
+        measurement_error=["Y"],
+        constant_params=["alpha"],
+        observation_equations={"Y": "log(Y[]) + alpha"},
+        verbose=False,
+    )
+
+    alpha_value = ss_mod.param_dict["alpha"]
+    obs_intercept = ss_mod.ssm["obs_intercept"]
+    alpha_leaves = [a for a in ancestors([obs_intercept]) if a.owner is None and a.name == "alpha"]
+    assert len(alpha_leaves) == 1
+    assert isinstance(alpha_leaves[0], TensorConstant)
+    np.testing.assert_allclose(alpha_leaves[0].data, alpha_value)


### PR DESCRIPTION
- `configure()` accepts `observation_equations` (GCN-syntax exprs)
- Linearized around steady state, compiled to pytensor
- Lagged refs via shift-companion lag-state chains
- Supports temporal aggregation and steady-state obs means